### PR TITLE
Variable count and names

### DIFF
--- a/readstat-sys/build.rs
+++ b/readstat-sys/build.rs
@@ -77,13 +77,17 @@ fn main() {
         .header("wrapper.h")
         // Select which functions and types to build bindings for
         .whitelist_function("readstat_get_row_count")
+        .whitelist_function("readstat_get_var_count")
         .whitelist_function("readstat_parse_sas7bdat")
         .whitelist_function("readstat_parser_free")
         .whitelist_function("readstat_parser_init")
         .whitelist_function("readstat_set_metadata_handler")
+        .whitelist_function("readstat_set_variable_handler")
+        .whitelist_function("readstat_variable_get_name")
         .whitelist_type("readstat_error_t")
         .whitelist_type("readstat_metadata_t")
         .whitelist_type("readstat_parser_t")
+        .whitelist_type("readstat_variable_t")
         .whitelist_type("READSTAT_HANDLER_OK")
         .whitelist_type("READSTAT_OK")
         // Tell cargo to invalidate the built crate whenever any of the

--- a/readstat/src/lib.rs
+++ b/readstat/src/lib.rs
@@ -4,7 +4,7 @@ use dunce;
 use log::debug;
 use readstat_sys;
 use std::error::Error;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
@@ -20,6 +20,20 @@ pub enum ReadStat {
         file: PathBuf,
         #[structopt(long, short)]
         raw: bool,
+    },
+    /// Get variable count
+    Vars {
+        #[structopt(parse(from_os_str))]
+        /// Path to sas7bdat file
+        file: PathBuf,
+        #[structopt(long, short)]
+        raw: bool,
+    },
+    /// Print vars
+    PrintVars {
+        #[structopt(parse(from_os_str))]
+        /// Path to sas7bdat file
+        file: PathBuf,
     },
 }
 
@@ -43,10 +57,34 @@ pub unsafe extern "C" fn handle_metadata(
     let mut md = &mut *(ctx as *mut ReadStatMetadata);
 
     let rc: c_int = readstat_sys::readstat_get_row_count(metadata);
+    let vc: c_int = readstat_sys::readstat_get_var_count(metadata);
 
     md.row_count = rc;
+    md.var_count = vc;
     debug!("md struct is {:#?}", md);
     debug!("row_count is {:#?}", md.row_count);
+    debug!("var_count is {:#?}", md.var_count);
+
+    ReadStatHandler::READSTAT_HANDLER_OK as c_int
+}
+
+pub unsafe extern "C" fn handle_variable(
+    #[allow(unused_variables)]
+    index: c_int,
+    variable: *mut readstat_sys::readstat_variable_t,
+    #[allow(unused_variables)]
+    val_labels: *const c_char,
+    ctx: *mut c_void,
+) -> c_int {
+    let md = &mut *(ctx as *mut ReadStatMetadata);
+
+    // FIXME
+    let var = CStr::from_ptr(readstat_sys::readstat_variable_get_name(variable)).to_str().unwrap();
+
+    md.vars.push(&var);
+
+    debug!("md struct is {:#?}", md);
+    debug!("var pushed is {:#?}", var);
 
     ReadStatHandler::READSTAT_HANDLER_OK as c_int
 }
@@ -65,14 +103,16 @@ pub fn path_to_cstring(path: &Path) -> Result<CString, InvalidPath> {
     CString::new(rust_str).map_err(|_| InvalidPath)
 }
 
-#[derive(Debug, Clone, PartialEq)]
-struct ReadStatMetadata {
+#[derive(Debug)]
+struct ReadStatMetadata<'a> {
     row_count: c_int,
+    var_count: c_int,
+    vars: Vec<&'a str>
 }
 
-impl ReadStatMetadata {
+impl ReadStatMetadata<'_> {
     fn new() -> Self {
-        Self { row_count: 0 }
+        Self { row_count: 0, var_count: 0, vars: Vec::new() }
     }
 }
 
@@ -88,7 +128,7 @@ impl ReadStatParser {
         Self { parser }
     }
 
-    fn set_metadata_handler_error(
+    fn set_metadata_handler(
         &self,
         metadata_handler: readstat_sys::readstat_metadata_handler,
     ) -> Result<(), Box<dyn Error>> {
@@ -104,6 +144,25 @@ impl ReadStatParser {
             Ok(())
         } else {
             Err(From::from("Unable to set metadata handler"))
+        }
+    }
+
+    fn set_variable_handler(
+        &self,
+        variable_handler: readstat_sys::readstat_variable_handler,
+    ) -> Result<(), Box<dyn Error>> {
+        let set_variable_handler_error =
+            unsafe { readstat_sys::readstat_set_variable_handler(self.parser, variable_handler) };
+
+        debug!(
+            "After setting variable handler, error ==> {}",
+            &set_variable_handler_error
+        );
+
+        if set_variable_handler_error == readstat_sys::readstat_error_e_READSTAT_OK {
+            Ok(())
+        } else {
+            Err(From::from("Unable to set variable handler"))
         }
     }
 
@@ -156,13 +215,72 @@ pub fn get_row_count(
 
     let parser = ReadStatParser::new();
 
-    parser.set_metadata_handler_error(Some(handle_metadata))?;
+    parser.set_metadata_handler(Some(handle_metadata))?;
 
     parser.parse_sas7bdat(psas_path_cstring, preadstat_md)?;
 
     let row_count = readstat_md.row_count;
 
     Ok((error, row_count))
+}
+
+pub fn get_var_count(
+    path: &PathBuf,
+) -> Result<(readstat_sys::readstat_error_t, i32), Box<dyn Error>> {
+    let sas_path_cstring = path_to_cstring(&path)?;
+    let psas_path_cstring = sas_path_cstring.as_ptr();
+
+    debug!(
+        "Counting the number of variables within the file {}",
+        path.to_string_lossy()
+    );
+    debug!("Path as C string is {:?}", sas_path_cstring);
+
+    let mut readstat_md = ReadStatMetadata::new() ;
+    let preadstat_md = &mut readstat_md as *mut ReadStatMetadata as *mut c_void;
+
+    let error: readstat_sys::readstat_error_t = readstat_sys::readstat_error_e_READSTAT_OK;
+    debug!("Initially, error ==> {}", &error);
+
+    let parser = ReadStatParser::new();
+
+    parser.set_metadata_handler(Some(handle_metadata))?;
+
+    parser.parse_sas7bdat(psas_path_cstring, preadstat_md)?;
+
+    let var_count = readstat_md.var_count;
+
+    Ok((error, var_count))
+}
+
+pub fn print_var_count(
+    path: &PathBuf,
+) -> Result<(readstat_sys::readstat_error_t, Vec<&str>), Box<dyn Error>> {
+    let sas_path_cstring = path_to_cstring(&path)?;
+    let psas_path_cstring = sas_path_cstring.as_ptr();
+
+    debug!(
+        "Printing the variables within the file {}",
+        path.to_string_lossy()
+    );
+    debug!("Path as C string is {:?}", sas_path_cstring);
+
+    let mut readstat_md = ReadStatMetadata::new() ;
+    let preadstat_md = &mut readstat_md as *mut ReadStatMetadata as *mut c_void;
+
+    let error: readstat_sys::readstat_error_t = readstat_sys::readstat_error_e_READSTAT_OK;
+    debug!("Initially, error ==> {}", &error);
+
+    let parser = ReadStatParser::new();
+
+    // parser.set_metadata_handler(Some(handle_metadata_vc))?;
+    parser.set_variable_handler(Some(handle_variable))?;
+
+    parser.parse_sas7bdat(psas_path_cstring, preadstat_md)?;
+
+    let vars = readstat_md.vars;
+
+    Ok((error, vars))
 }
 
 pub fn run(rs: ReadStat) -> Result<(), Box<dyn Error>> {
@@ -177,12 +295,46 @@ pub fn run(rs: ReadStat) -> Result<(), Box<dyn Error>> {
             } else {
                 if !raw {
                     println!(
-                        "The file {:#?} contains {:#?} records",
+                        "The file {:#?} contains {:#?} rows",
                         &sas_path.display(),
                         record_count
                     );
                 } else {
                     println!("{}", record_count);
+                }
+                Ok(())
+            }
+        },
+        ReadStat::Vars { file, raw } => {
+            let sas_path = dunce::canonicalize(&file)?;
+            let (error, var_count) = get_var_count(&sas_path)?;
+            if error != readstat_sys::readstat_error_e_READSTAT_OK {
+                Err(From::from("Error when attempting to parse sas7bdat"))
+            } else {
+                if !raw {
+                    println!(
+                        "The file {:#?} contains {:#?} variables",
+                        &sas_path.display(),
+                        var_count
+                    );
+                } else {
+                    println!("{}", var_count);
+                }
+                Ok(())
+            }
+        },
+        ReadStat::PrintVars { file, } => {
+            let sas_path = dunce::canonicalize(&file)?;
+            let (error, vars) = print_var_count(&sas_path)?;
+            if error != readstat_sys::readstat_error_e_READSTAT_OK {
+                Err(From::from("Error when attempting to parse sas7bdat"))
+            } else {
+                println!(
+                    "The file {:#?} contains the following variables:",
+                    &sas_path.display(),
+                );
+                for v in vars.iter() {
+                    println!("{:?}", v);
                 }
                 Ok(())
             }


### PR DESCRIPTION
Variable count and names!  In future will probably combine subcommands into a single command to dump all metadata.  The internal implementation grabs row count and variable count in a single method call.  However these are only accessible from separate subcommands.  For now we are still exploring and trying to figure out the API.