### PR TITLE
Add support for Parquet compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ To write the first 100 rows of parsed data (as `parquet`) to a file, invoke the 
 readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --format parquet --rows 100
 ```
 
+To write parsed data (as `parquet`) to a file with specific compression settings, invoke the following:
+
+```sh
+readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --format parquet --compression zstd --compression-level 3
+```
+
 ### Parallelism
 The `data` subcommand includes a parameter for `--parallel` &mdash; if invoked, the _**reading**_ of a `sas7bdat` will occur in parallel.  If the total rows to process is greater than `stream-rows` (if unset, the default rows to stream is 10,000), then each chunk of rows is read in parallel.  Note that all processors on the user's machine are used with the `--parallel` option.  In the future, may consider allowing the user to throttle this number.
 

--- a/crates/readstat/src/lib.rs
+++ b/crates/readstat/src/lib.rs
@@ -105,6 +105,12 @@ pub enum ReadStatCliCommands {
         /// Convert sas7bdat data in parallel
         #[arg(action, long)]
         parallel: bool,
+        /// Parquet compression algorithm
+        #[arg(long, value_enum, value_parser)]
+        compression: Option<ParquetCompression>,
+        /// Parquet compression level (if applicable)
+        #[arg(long, value_parser = clap::value_parser!(u32).range(0..=22))]
+        compression_level: Option<u32>,
     },
 }
 
@@ -135,6 +141,23 @@ impl fmt::Display for Reader {
         write!(f, "{:?}", &self)
     }
 }
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ParquetCompression {
+    Uncompressed,
+    Snappy,
+    Gzip,
+    Lzo,
+    Brotli,
+    Zstd,
+}
+
+impl fmt::Display for ParquetCompression {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", &self)
+    }
+}
+
 pub fn run(rs: ReadStatCli) -> Result<(), Box<dyn Error + Send + Sync>> {
     env_logger::init();
 
@@ -153,7 +176,7 @@ pub fn run(rs: ReadStatCli) -> Result<(), Box<dyn Error + Send + Sync>> {
             );
 
             // out_path and format determine the type of writing performed
-            let rsp = ReadStatPath::new(sas_path, None, None, false, false)?;
+            let rsp = ReadStatPath::new(sas_path, None, None, false, false, None, None)?;
 
             // Instantiate ReadStatMetadata
             let mut md = ReadStatMetadata::new();
@@ -182,7 +205,15 @@ pub fn run(rs: ReadStatCli) -> Result<(), Box<dyn Error + Send + Sync>> {
             );
 
             // output and format determine the type of writing to be performed
-            let rsp = ReadStatPath::new(sas_path, None, Some(OutFormat::csv), false, false)?;
+            let rsp = ReadStatPath::new(
+                sas_path,
+                None,
+                Some(OutFormat::csv),
+                false,
+                false,
+                None,
+                None,
+            )?;
 
             // instantiate ReadStatMetadata
             let mut md = ReadStatMetadata::new();
@@ -262,6 +293,8 @@ pub fn run(rs: ReadStatCli) -> Result<(), Box<dyn Error + Send + Sync>> {
             no_progress,
             overwrite,
             parallel,
+            compression,
+            compression_level,
         } => {
             // Validate and create path to sas7bdat/sas7bcat
             let sas_path = PathAbs::new(input)?.as_path().to_path_buf();
@@ -271,7 +304,15 @@ pub fn run(rs: ReadStatCli) -> Result<(), Box<dyn Error + Send + Sync>> {
             );
 
             // output and format determine the type of writing to be performed
-            let rsp = ReadStatPath::new(sas_path, output, format, overwrite, false)?;
+            let rsp = ReadStatPath::new(
+                sas_path,
+                output,
+                format,
+                overwrite,
+                false,
+                compression,
+                compression_level,
+            )?;
 
             // Instantiate ReadStatMetadata
             let mut md = ReadStatMetadata::new();

--- a/crates/readstat/src/rs_path.rs
+++ b/crates/readstat/src/rs_path.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use crate::OutFormat;
+use crate::ParquetCompression;
 
 const IN_EXTENSIONS: &[&str] = &["sas7bdat", "sas7bcat"];
 
@@ -19,6 +20,8 @@ pub struct ReadStatPath {
     pub format: OutFormat,
     pub overwrite: bool,
     pub no_write: bool,
+    pub compression: Option<ParquetCompression>,
+    pub compression_level: Option<u32>,
 }
 
 impl ReadStatPath {
@@ -28,6 +31,8 @@ impl ReadStatPath {
         format: Option<OutFormat>,
         overwrite: bool,
         no_write: bool,
+        compression: Option<ParquetCompression>,
+        compression_level: Option<u32>,
     ) -> Result<Self, Box<dyn Error + Send + Sync>> {
         let p = Self::validate_path(path)?;
         let ext = Self::validate_in_extension(&p)?;
@@ -47,6 +52,8 @@ impl ReadStatPath {
             format: f,
             overwrite,
             no_write,
+            compression,
+            compression_level,
         })
     }
 

--- a/crates/readstat/src/rs_write.rs
+++ b/crates/readstat/src/rs_write.rs
@@ -18,6 +18,7 @@ use crate::rs_metadata::ReadStatMetadata;
 use crate::rs_path::ReadStatPath;
 use crate::rs_var::ReadStatVarFormatClass;
 use crate::OutFormat;
+use crate::ParquetCompression;
 
 pub struct ReadStatParquetWriter {
     wtr: Box<parquet_arrow2::write::FileWriter<std::fs::File>>,
@@ -467,7 +468,42 @@ impl ReadStatWriter {
             if !self.wrote_start {
                 let options = parquet_arrow2::write::WriteOptions {
                     write_statistics: true,
-                    compression: parquet_arrow2::write::CompressionOptions::Snappy,
+                    compression: match rsp.compression {
+                        Some(ParquetCompression::Uncompressed) => parquet_arrow2::write::CompressionOptions::Uncompressed,
+                        Some(ParquetCompression::Snappy) => parquet_arrow2::write::CompressionOptions::Snappy,
+                        Some(ParquetCompression::Gzip) => {
+                            if let Some(level) = rsp.compression_level {
+                                let gzip_level = parquet_arrow2::write::GzipLevel::try_new(level.try_into()
+                                    .map_err(|_| "Invalid Gzip compression level")?
+                                ).map_err(|_| "Invalid Gzip compression level")?;
+                                parquet_arrow2::write::CompressionOptions::Gzip(Some(gzip_level))
+                            } else {
+                                parquet_arrow2::write::CompressionOptions::Gzip(None)
+                            }
+                        },
+                        Some(ParquetCompression::Lzo) => parquet_arrow2::write::CompressionOptions::Lzo,
+                        Some(ParquetCompression::Brotli) => {
+                            if let Some(level) = rsp.compression_level {
+                                let brotli_level = parquet_arrow2::write::BrotliLevel::try_new(level.try_into()
+                                    .map_err(|_| "Invalid Brotli compression level")?
+                                ).map_err(|_| "Invalid Brotli compression level")?;
+                                parquet_arrow2::write::CompressionOptions::Brotli(Some(brotli_level))
+                            } else {
+                                parquet_arrow2::write::CompressionOptions::Brotli(None)
+                            }
+                        },
+                        Some(ParquetCompression::Zstd) => {
+                            if let Some(level) = rsp.compression_level {
+                                let zstd_level = parquet_arrow2::write::ZstdLevel::try_new(level.try_into()
+                                    .map_err(|_| "Invalid Zstd compression level")?
+                                ).map_err(|_| "Invalid Zstd compression level")?;
+                                parquet_arrow2::write::CompressionOptions::Zstd(Some(zstd_level))
+                            } else {
+                                parquet_arrow2::write::CompressionOptions::Zstd(None)
+                            }
+                        },
+                        None => parquet_arrow2::write::CompressionOptions::Snappy,
+                    },
                     version: parquet_arrow2::write::Version::V2,
                     data_pagesize_limit: None 
                 };


### PR DESCRIPTION
Added support for specifying Parquet compression options when converting SAS files to Parquet format.
Enhanced the CLI tool's capabilities by providing more control over Parquet file compression.

1. `README.md` updates:
 - Added a new example showing how to use the CLI tool with specific compression settings for Parquet output.
2. `lib.rs` updates:
 - Added new optional arguments for compression and compression level to the `ReadStatCliCommands::Data` variant.
 - Introduced a new ParquetCompression enum.
 - Updated ReadStatPath::new() function calls with new parameters.
3. `rs_path.rs` updates:
- Modified the `ReadStatPath` struct to include new compression type and level fields.
- Updated the `new()` function to accept and set these new fields.
4. `rs_write.rs` updates:
- Modified the `write_data_to_parquet()` function to handle the new compression options.
- Implemented logic to apply the specified compression algorithm and level when writing Parquet files.
- Added error handling for invalid compression levels while still allowing default values when no level is specified.

Note: the CLI parser only checks that `COMPRESSION_LEVEL` is valid for at least one compression method (between 0 and 22), but not that the compression level is valid for the specified compression method. If the provided level is invalid for the method, an error will occur on the first write attempt, and an error message will be shown.