### PR TITLE
Fix Linux musl build by making libz-sys an unconditional dependency

### DIFF
--- a/crates/readstat-sys/Cargo.toml
+++ b/crates/readstat-sys/Cargo.toml
@@ -13,6 +13,8 @@ build = "build.rs"
 bindgen = "0.72"
 cc = "1.2"
 
+[dependencies]
+libz-sys = "1.1"
+
 [target.'cfg(windows)'.dependencies]
 iconv-sys = { path = "../iconv-sys", version = "0.2.0" }
-libz-sys = "1.1"

--- a/crates/readstat-sys/build.rs
+++ b/crates/readstat-sys/build.rs
@@ -79,16 +79,15 @@ fn main() {
     }
 
     // Linking
+    // Note: zlib linking is handled by the libz-sys crate dependency
     if target.contains("windows-msvc") {
         // Path to libclang
         if env::var_os("LIBCLANG_PATH").is_none() {
             println!("cargo:rustc-env=LIBCLANG_PATH='C:/Program Files/LLVM/lib'");
         }
         println!("cargo:rustc-link-lib=static=iconv");
-        println!("cargo:rustc-link-lib=static=z");
     } else if target.contains("apple-darwin") {
         println!("cargo:rustc-link-lib=iconv");
-        println!("cargo:rustc-link-lib=z");
     }
 
     // Compile


### PR DESCRIPTION
The musl compiler doesn't search /usr/include/ by default, so zlib.h was not found during the readstat-sys build. Moving libz-sys from a Windows-only dependency to unconditional ensures DEP_Z_INCLUDE is set on all platforms, and lets libz-sys handle zlib linking everywhere.