### PR TITLE
Replace unwrap() calls with typed error handling using thiserror

### DIFF
--- a/crates/readstat-tests/tests/common/mod.rs
+++ b/crates/readstat-tests/tests/common/mod.rs
@@ -1,6 +1,5 @@
 use arrow::datatypes::DataType;
 use path_abs::PathAbs;
-use std::{error::Error, result::Result};
 
 #[allow(dead_code)]
 pub fn contains_var(d: &readstat::ReadStatData, var_index: i32) -> bool {
@@ -37,7 +36,7 @@ pub fn get_var_attrs(
 }
 
 #[allow(dead_code)]
-pub fn setup_path<P>(ds: P) -> Result<readstat::ReadStatPath, Box<dyn Error + Send + Sync>>
+pub fn setup_path<P>(ds: P) -> Result<readstat::ReadStatPath, readstat::ReadStatError>
 where
     P: AsRef<std::path::Path>,
 {

--- a/crates/readstat/Cargo.toml
+++ b/crates/readstat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readstat"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Curtis Alexander <calex@calex.org>"]
 edition = "2024"
 description = "Rust wrapper of the ReadStat C library"
@@ -42,6 +42,7 @@ readstat-sys = { path = "../readstat-sys", version = "0.2.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
+thiserror = "2"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/readstat/src/common.rs
+++ b/crates/readstat/src/common.rs
@@ -1,10 +1,11 @@
-use std::error::Error;
 use std::ffi::CStr;
+
+use crate::err::ReadStatError;
 
 pub fn build_offsets(
     row_count: u32,
     stream_rows: u32,
-) -> Result<Vec<u32>, Box<dyn Error + Send + Sync>> {
+) -> Result<Vec<u32>, ReadStatError> {
     // Get number of chunks
     let chunks = if stream_rows < row_count {
         if row_count % stream_rows == 0 {

--- a/crates/readstat/src/rs_parser.rs
+++ b/crates/readstat/src/rs_parser.rs
@@ -1,11 +1,7 @@
 use log::debug;
-use num_traits::FromPrimitive;
-use std::{
-    error::Error,
-    os::raw::{c_char, c_long, c_void},
-};
+use std::os::raw::{c_char, c_long, c_void};
 
-use crate::err::ReadStatError;
+use crate::err::{check_c_error, ReadStatError};
 
 pub struct ReadStatParser {
     parser: *mut readstat_sys::readstat_parser_t,
@@ -22,7 +18,7 @@ impl ReadStatParser {
     pub fn set_metadata_handler(
         self,
         metadata_handler: readstat_sys::readstat_metadata_handler,
-    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Self, ReadStatError> {
         let set_metadata_handler_error =
             unsafe { readstat_sys::readstat_set_metadata_handler(self.parser, metadata_handler) };
 
@@ -31,23 +27,14 @@ impl ReadStatParser {
             &set_metadata_handler_error
         );
 
-        #[allow(clippy::useless_conversion)]
-        match FromPrimitive::from_i32(set_metadata_handler_error.try_into().unwrap()) {
-            Some(ReadStatError::READSTAT_OK) => Ok(self),
-            Some(e) => Err(From::from(format!(
-                "Unable to set metdata handler: {:#?}",
-                e
-            ))),
-            None => Err(From::from(
-                "Error when attempting to set metadata handler: Unknown return value",
-            )),
-        }
+        check_c_error(set_metadata_handler_error as i32)?;
+        Ok(self)
     }
 
     pub fn set_row_limit(
         self,
         row_limit: Option<u32>,
-    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Self, ReadStatError> {
         match row_limit {
             Some(r) => {
                 let set_row_limit_error =
@@ -58,14 +45,8 @@ impl ReadStatParser {
                     &set_row_limit_error
                 );
 
-                #[allow(clippy::useless_conversion)]
-                match FromPrimitive::from_i32(set_row_limit_error.try_into().unwrap()) {
-                    Some(ReadStatError::READSTAT_OK) => Ok(self),
-                    Some(e) => Err(From::from(format!("Unable to set row limit: {:#?}", e))),
-                    None => Err(From::from(
-                        "Error when attempting to set row limit: Unknown return value",
-                    )),
-                }
+                check_c_error(set_row_limit_error as i32)?;
+                Ok(self)
             }
             None => Ok(self),
         }
@@ -74,7 +55,7 @@ impl ReadStatParser {
     pub fn set_row_offset(
         self,
         row_offset: Option<u32>,
-    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Self, ReadStatError> {
         match row_offset {
             Some(r) => {
                 let set_row_offset_error =
@@ -85,14 +66,8 @@ impl ReadStatParser {
                     &set_row_offset_error
                 );
 
-                #[allow(clippy::useless_conversion)]
-                match FromPrimitive::from_i32(set_row_offset_error.try_into().unwrap()) {
-                    Some(ReadStatError::READSTAT_OK) => Ok(self),
-                    Some(e) => Err(From::from(format!("Unable to set row limit: {:#?}", e))),
-                    None => Err(From::from(
-                        "Error when attempting to set row limit: Unknown return value",
-                    )),
-                }
+                check_c_error(set_row_offset_error as i32)?;
+                Ok(self)
             }
             None => Ok(self),
         }
@@ -101,7 +76,7 @@ impl ReadStatParser {
     pub fn set_variable_handler(
         self,
         variable_handler: readstat_sys::readstat_variable_handler,
-    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Self, ReadStatError> {
         let set_variable_handler_error =
             unsafe { readstat_sys::readstat_set_variable_handler(self.parser, variable_handler) };
 
@@ -110,23 +85,14 @@ impl ReadStatParser {
             &set_variable_handler_error
         );
 
-        #[allow(clippy::useless_conversion)]
-        match FromPrimitive::from_i32(set_variable_handler_error.try_into().unwrap()) {
-            Some(ReadStatError::READSTAT_OK) => Ok(self),
-            Some(e) => Err(From::from(format!(
-                "Unable to set variable handler: {:#?}",
-                e
-            ))),
-            None => Err(From::from(
-                "Error when attempting to set variable handler: Unknown return value",
-            )),
-        }
+        check_c_error(set_variable_handler_error as i32)?;
+        Ok(self)
     }
 
     pub fn set_value_handler(
         self,
         value_handler: readstat_sys::readstat_value_handler,
-    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Self, ReadStatError> {
         let set_value_handler_error =
             unsafe { readstat_sys::readstat_set_value_handler(self.parser, value_handler) };
 
@@ -135,14 +101,8 @@ impl ReadStatParser {
             &set_value_handler_error
         );
 
-        #[allow(clippy::useless_conversion)]
-        match FromPrimitive::from_i32(set_value_handler_error.try_into().unwrap()) {
-            Some(ReadStatError::READSTAT_OK) => Ok(self),
-            Some(e) => Err(From::from(format!("Unable to set value handler: {:#?}", e))),
-            None => Err(From::from(
-                "Error when attempting to set value handler: Unknown return value",
-            )),
-        }
+        check_c_error(set_value_handler_error as i32)?;
+        Ok(self)
     }
 
     pub fn parse_sas7bdat(


### PR DESCRIPTION
## Summary
- Introduce `thiserror`-based `ReadStatError` enum replacing `Box<dyn Error + Send + Sync>` across the crate, giving library consumers structured, matchable error types
- Remove ~15 `unwrap()` calls in production code, replacing them with proper `?` propagation, `.ok_or()`, and `.unwrap_or_default()` as appropriate
- Rename the original C error code enum to `ReadStatCError`, wrapped by `ReadStatError::CLibrary`
- Bump crate version to **v0.16.0**

## Test plan
- [x] `cargo build` compiles cleanly with no warnings
- [x] `cargo test --workspace` — all 106 tests pass
- [x] `cargo clippy --workspace` — no new warnings from readstat crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)