### PR TITLE
Fix Windows CI by updating install-llvm-action to v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
           path: ${{ runner.temp }}\llvm
           key: llvm-21.1.8
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
+        uses: KyleMayes/install-llvm-action@v2
         with:
           # versions - https://github.com/KyleMayes/install-llvm-action/blob/master/assets.json
           version: "21.1.8"


### PR DESCRIPTION
The v1 tag doesn't have LLVM 21.1.8 in its assets manifest for Windows, causing "Unsupported target" errors. The v2 release supports 21.1.8 across all platforms.