### PR TITLE
Add support for reading SAS files from in-memory byte slices

### DIFF
--- a/crates/readstat-sys/build.rs
+++ b/crates/readstat-sys/build.rs
@@ -137,6 +137,13 @@ fn main() {
         .allowlist_function("readstat_set_progress_handler")
         .allowlist_function("readstat_set_row_limit")
         .allowlist_function("readstat_set_row_offset")
+        // I/O handlers (for buffer-based / custom I/O)
+        .allowlist_function("readstat_set_open_handler")
+        .allowlist_function("readstat_set_close_handler")
+        .allowlist_function("readstat_set_seek_handler")
+        .allowlist_function("readstat_set_read_handler")
+        .allowlist_function("readstat_set_update_handler")
+        .allowlist_function("readstat_set_io_ctx")
         // Metadata
         .allowlist_function("readstat_get_row_count")
         .allowlist_function("readstat_get_var_count")
@@ -195,6 +202,10 @@ fn main() {
         .allowlist_type("readstat_value_t")
         // Parsing
         .allowlist_type("readstat_parser_t")
+        // I/O types (for buffer-based / custom I/O)
+        .allowlist_type("readstat_off_t")
+        .allowlist_type("readstat_io_flags_t")
+        .allowlist_type("readstat_io_flags_e")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))

--- a/crates/readstat-tests/tests/bytes_reading_test.rs
+++ b/crates/readstat-tests/tests/bytes_reading_test.rs
@@ -1,0 +1,194 @@
+use arrow::datatypes::DataType;
+use common::ExpectedMetadata;
+
+mod common;
+
+/// Helper: reads a test dataset file into bytes.
+fn read_test_file_bytes(dataset: &str) -> Vec<u8> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("data")
+        .join(dataset);
+    std::fs::read(path).unwrap()
+}
+
+/// Helper: reads metadata + data from bytes and returns (metadata, data).
+fn setup_and_read_from_bytes(
+    dataset: &str,
+) -> (readstat::ReadStatMetadata, readstat::ReadStatData) {
+    let bytes = read_test_file_bytes(dataset);
+
+    let mut md = readstat::ReadStatMetadata::new();
+    md.read_metadata_from_bytes(&bytes, false).unwrap();
+
+    let mut d = readstat::ReadStatData::new()
+        .set_no_progress(true)
+        .init(md.clone(), 0, md.row_count as u32);
+    d.read_data_from_bytes(&bytes).unwrap();
+
+    (md, d)
+}
+
+// ── Metadata tests ─────────────────────────────────────────────────
+
+#[test]
+fn bytes_cars_metadata_matches_file() {
+    let (md, _d) = setup_and_read_from_bytes("cars.sas7bdat");
+
+    common::assert_metadata(&md, &ExpectedMetadata {
+        row_count: 1081,
+        var_count: 13,
+        table_name: "CARS",
+        file_label: "Written by SAS",
+        file_encoding: "WINDOWS-1252",
+        version: 9,
+        is64bit: 0,
+        creation_time: "2008-09-30 12:55:01",
+        modified_time: "2008-09-30 12:55:01",
+    });
+
+    assert!(matches!(md.compression, readstat::ReadStatCompress::None));
+    assert!(matches!(md.endianness, readstat::ReadStatEndian::Little));
+}
+
+#[test]
+fn bytes_cars_variable_types() {
+    let (_md, d) = setup_and_read_from_bytes("cars.sas7bdat");
+
+    // 0 - Brand (String)
+    let (vtc, vt, vfc, vf, adt) = common::get_var_attrs(&d, 0);
+    assert!(matches!(vtc, readstat::ReadStatVarTypeClass::String));
+    assert!(matches!(vt, readstat::ReadStatVarType::String));
+    assert!(vfc.is_none());
+    assert_eq!(vf, "");
+    assert!(matches!(adt, DataType::Utf8));
+
+    // 2..12 - All numeric Double -> Float64
+    for i in 2..=12 {
+        let (vtc, vt, _vfc, _vf, adt) = common::get_var_attrs(&d, i);
+        assert!(matches!(vtc, readstat::ReadStatVarTypeClass::Numeric), "var {i}");
+        assert!(matches!(vt, readstat::ReadStatVarType::Double), "var {i}");
+        assert!(matches!(adt, DataType::Float64), "var {i}");
+    }
+}
+
+// ── Data tests ─────────────────────────────────────────────────────
+
+#[test]
+fn bytes_cars_data_matches_file() {
+    let (_md, d) = setup_and_read_from_bytes("cars.sas7bdat");
+
+    let batch = d.batch.as_ref().unwrap();
+    assert_eq!(batch.num_rows(), 1081);
+
+    // Spot-check row 0
+    let brand = common::get_string_col(batch, 0);
+    let model = common::get_string_col(batch, 1);
+    let engine_size = common::get_f64_col(batch, 6);
+
+    assert_eq!(brand.value(0), "TOYOTA");
+    assert_eq!(model.value(0), "Prius");
+    assert_eq!(engine_size.value(0), 1.5);
+
+    // Row 1
+    assert_eq!(brand.value(1), "HONDA");
+    assert_eq!(model.value(1), "Civic Hybrid");
+}
+
+#[test]
+fn bytes_all_types_data() {
+    let (_md, d) = setup_and_read_from_bytes("all_types.sas7bdat");
+    let batch = d.batch.as_ref().unwrap();
+    assert!(batch.num_rows() > 0);
+}
+
+#[test]
+fn bytes_dates_data() {
+    let (_md, d) = setup_and_read_from_bytes("all_dates.sas7bdat");
+    let batch = d.batch.as_ref().unwrap();
+    assert!(batch.num_rows() > 0);
+}
+
+#[test]
+fn bytes_datetimes_data() {
+    let (_md, d) = setup_and_read_from_bytes("all_datetimes.sas7bdat");
+    let batch = d.batch.as_ref().unwrap();
+    assert!(batch.num_rows() > 0);
+}
+
+#[test]
+fn bytes_hasmissing_data() {
+    let (_md, d) = setup_and_read_from_bytes("hasmissing.sas7bdat");
+    let batch = d.batch.as_ref().unwrap();
+    assert!(batch.num_rows() > 0);
+}
+
+// ── Metadata-only (skip row count) ─────────────────────────────────
+
+#[test]
+fn bytes_metadata_skip_row_count() {
+    let bytes = read_test_file_bytes("cars.sas7bdat");
+    let mut md = readstat::ReadStatMetadata::new();
+    md.read_metadata_from_bytes(&bytes, true).unwrap();
+
+    // Variable metadata should still be populated
+    assert_eq!(md.var_count, 13);
+    assert_eq!(md.table_name, "CARS");
+}
+
+// ── Streaming chunks from bytes ────────────────────────────────────
+
+#[test]
+fn bytes_streaming_chunks() {
+    let bytes = read_test_file_bytes("cars.sas7bdat");
+
+    let mut md = readstat::ReadStatMetadata::new();
+    md.read_metadata_from_bytes(&bytes, false).unwrap();
+
+    let total_rows = md.row_count as u32;
+    let offsets = readstat::build_offsets(total_rows, 500).unwrap();
+    let mut total_read = 0usize;
+
+    for w in offsets.windows(2) {
+        let mut d = readstat::ReadStatData::new()
+            .set_no_progress(true)
+            .init(md.clone(), w[0], w[1]);
+        d.read_data_from_bytes(&bytes).unwrap();
+        let batch = d.batch.as_ref().unwrap();
+        total_read += batch.num_rows();
+    }
+
+    assert_eq!(total_read, total_rows as usize);
+}
+
+// ── Comparison: bytes vs file produce identical results ─────────────
+
+#[test]
+fn bytes_vs_file_identical_results() {
+    // Read via file
+    let (_rsp, file_md, file_d) = common::setup_and_read("cars.sas7bdat");
+
+    // Read via bytes
+    let (bytes_md, bytes_d) = setup_and_read_from_bytes("cars.sas7bdat");
+
+    // Metadata should match
+    assert_eq!(file_md.row_count, bytes_md.row_count);
+    assert_eq!(file_md.var_count, bytes_md.var_count);
+    assert_eq!(file_md.table_name, bytes_md.table_name);
+    assert_eq!(file_md.file_label, bytes_md.file_label);
+    assert_eq!(file_md.file_encoding, bytes_md.file_encoding);
+
+    // RecordBatches should be identical
+    let file_batch = file_d.batch.as_ref().unwrap();
+    let bytes_batch = bytes_d.batch.as_ref().unwrap();
+    assert_eq!(file_batch.num_rows(), bytes_batch.num_rows());
+    assert_eq!(file_batch.num_columns(), bytes_batch.num_columns());
+    assert_eq!(file_batch.schema(), bytes_batch.schema());
+
+    // Spot-check actual data values
+    let file_brand = common::get_string_col(file_batch, 0);
+    let bytes_brand = common::get_string_col(bytes_batch, 0);
+    for i in 0..file_batch.num_rows() {
+        assert_eq!(file_brand.value(i), bytes_brand.value(i), "row {i}");
+    }
+}

--- a/crates/readstat/src/lib.rs
+++ b/crates/readstat/src/lib.rs
@@ -93,6 +93,7 @@ mod cb;
 mod common;
 mod err;
 mod formats;
+mod rs_buffer_io;
 mod rs_data;
 mod rs_metadata;
 mod rs_parser;

--- a/crates/readstat/src/rs_buffer_io.rs
+++ b/crates/readstat/src/rs_buffer_io.rs
@@ -1,0 +1,158 @@
+//! Buffer-based I/O handlers for parsing SAS files from in-memory byte slices.
+//!
+//! Provides [`ReadStatBufferCtx`] and a set of `extern "C"` callback functions that
+//! implement the ReadStat I/O interface over a `&[u8]` buffer instead of a file.
+//! This enables parsing `.sas7bdat` data without filesystem access — useful for
+//! WASM targets, cloud storage, HTTP uploads, and testing.
+
+use std::os::raw::{c_char, c_int, c_long, c_void};
+use std::ptr;
+
+use crate::err::ReadStatError;
+use crate::rs_parser::ReadStatParser;
+
+/// In-memory buffer context for ReadStat I/O callbacks.
+///
+/// Wraps a borrowed byte slice and tracks the current read position.
+/// Passed as the `io_ctx` pointer to all I/O handler callbacks.
+#[repr(C)]
+pub struct ReadStatBufferCtx {
+    data: *const u8,
+    len: usize,
+    pos: usize,
+}
+
+impl ReadStatBufferCtx {
+    /// Creates a new buffer context from a byte slice.
+    ///
+    /// The caller must ensure the byte slice outlives the context and any
+    /// parsing operations that use it.
+    pub fn new(bytes: &[u8]) -> Self {
+        Self {
+            data: bytes.as_ptr(),
+            len: bytes.len(),
+            pos: 0,
+        }
+    }
+
+    /// Configures a [`ReadStatParser`] to read from this buffer context
+    /// instead of from a file.
+    pub fn configure_parser(
+        &mut self,
+        parser: ReadStatParser,
+    ) -> Result<ReadStatParser, ReadStatError> {
+        let ctx_ptr = self as *mut ReadStatBufferCtx as *mut c_void;
+        parser
+            .set_open_handler(Some(buffer_open))
+            .and_then(|p| p.set_close_handler(Some(buffer_close)))
+            .and_then(|p| p.set_seek_handler(Some(buffer_seek)))
+            .and_then(|p| p.set_read_handler(Some(buffer_read)))
+            .and_then(|p| p.set_update_handler(Some(buffer_update)))
+            .and_then(|p| p.set_io_ctx(ctx_ptr))
+    }
+}
+
+/// No-op open handler — the buffer is already "open".
+unsafe extern "C" fn buffer_open(_path: *const c_char, _io_ctx: *mut c_void) -> c_int {
+    0
+}
+
+/// No-op close handler — nothing to close for an in-memory buffer.
+unsafe extern "C" fn buffer_close(_io_ctx: *mut c_void) -> c_int {
+    0
+}
+
+/// Seek handler that repositions the read cursor within the buffer.
+unsafe extern "C" fn buffer_seek(
+    offset: readstat_sys::readstat_off_t,
+    whence: readstat_sys::readstat_io_flags_t,
+    io_ctx: *mut c_void,
+) -> readstat_sys::readstat_off_t {
+    let ctx = unsafe { &mut *(io_ctx as *mut ReadStatBufferCtx) };
+
+    let newpos: i64 = match whence {
+        readstat_sys::readstat_io_flags_e_READSTAT_SEEK_SET => offset,
+        readstat_sys::readstat_io_flags_e_READSTAT_SEEK_CUR => ctx.pos as i64 + offset,
+        readstat_sys::readstat_io_flags_e_READSTAT_SEEK_END => ctx.len as i64 + offset,
+        _ => return -1,
+    };
+
+    if newpos < 0 || newpos > ctx.len as i64 {
+        return -1;
+    }
+
+    ctx.pos = newpos as usize;
+    newpos
+}
+
+/// Read handler that copies bytes from the buffer into the caller's buffer.
+unsafe extern "C" fn buffer_read(
+    buf: *mut c_void,
+    nbytes: usize,
+    io_ctx: *mut c_void,
+) -> isize {
+    let ctx = unsafe { &mut *(io_ctx as *mut ReadStatBufferCtx) };
+    let bytes_left = ctx.len.saturating_sub(ctx.pos);
+
+    let to_copy = if nbytes <= bytes_left {
+        nbytes
+    } else if bytes_left > 0 {
+        bytes_left
+    } else {
+        return 0;
+    };
+
+    unsafe {
+        ptr::copy_nonoverlapping(ctx.data.add(ctx.pos), buf as *mut u8, to_copy);
+    }
+    ctx.pos += to_copy;
+    to_copy as isize
+}
+
+/// Update/progress handler for buffer I/O.
+unsafe extern "C" fn buffer_update(
+    _file_size: c_long,
+    progress_handler: readstat_sys::readstat_progress_handler,
+    user_ctx: *mut c_void,
+    io_ctx: *mut c_void,
+) -> readstat_sys::readstat_error_t {
+    let handler = match progress_handler {
+        Some(h) => h,
+        None => return readstat_sys::readstat_error_e_READSTAT_OK,
+    };
+
+    let ctx = unsafe { &*(io_ctx as *mut ReadStatBufferCtx) };
+    let progress = if ctx.len > 0 {
+        ctx.pos as f64 / ctx.len as f64
+    } else {
+        1.0
+    };
+
+    if unsafe { handler(progress, user_ctx) } != 0 {
+        return readstat_sys::readstat_error_e_READSTAT_ERROR_USER_ABORT;
+    }
+
+    readstat_sys::readstat_error_e_READSTAT_OK
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_ctx_new() {
+        let data = vec![1u8, 2, 3, 4, 5];
+        let ctx = ReadStatBufferCtx::new(&data);
+        assert_eq!(ctx.len, 5);
+        assert_eq!(ctx.pos, 0);
+        assert_eq!(ctx.data, data.as_ptr());
+    }
+
+    #[test]
+    fn buffer_ctx_empty() {
+        let data: Vec<u8> = vec![];
+        let ctx = ReadStatBufferCtx::new(&data);
+        assert_eq!(ctx.len, 0);
+        assert_eq!(ctx.pos, 0);
+    }
+}

--- a/crates/readstat/src/rs_parser.rs
+++ b/crates/readstat/src/rs_parser.rs
@@ -122,6 +122,74 @@ impl ReadStatParser {
         Ok(self)
     }
 
+    /// Registers a custom handler for opening the data source.
+    pub fn set_open_handler(
+        self,
+        open_handler: readstat_sys::readstat_open_handler,
+    ) -> Result<Self, ReadStatError> {
+        let error =
+            unsafe { readstat_sys::readstat_set_open_handler(self.parser, open_handler) };
+        debug!("After setting open handler, error ==> {}", &error);
+        check_c_error(error as i32)?;
+        Ok(self)
+    }
+
+    /// Registers a custom handler for closing the data source.
+    pub fn set_close_handler(
+        self,
+        close_handler: readstat_sys::readstat_close_handler,
+    ) -> Result<Self, ReadStatError> {
+        let error =
+            unsafe { readstat_sys::readstat_set_close_handler(self.parser, close_handler) };
+        debug!("After setting close handler, error ==> {}", &error);
+        check_c_error(error as i32)?;
+        Ok(self)
+    }
+
+    /// Registers a custom handler for seeking within the data source.
+    pub fn set_seek_handler(
+        self,
+        seek_handler: readstat_sys::readstat_seek_handler,
+    ) -> Result<Self, ReadStatError> {
+        let error =
+            unsafe { readstat_sys::readstat_set_seek_handler(self.parser, seek_handler) };
+        debug!("After setting seek handler, error ==> {}", &error);
+        check_c_error(error as i32)?;
+        Ok(self)
+    }
+
+    /// Registers a custom handler for reading from the data source.
+    pub fn set_read_handler(
+        self,
+        read_handler: readstat_sys::readstat_read_handler,
+    ) -> Result<Self, ReadStatError> {
+        let error =
+            unsafe { readstat_sys::readstat_set_read_handler(self.parser, read_handler) };
+        debug!("After setting read handler, error ==> {}", &error);
+        check_c_error(error as i32)?;
+        Ok(self)
+    }
+
+    /// Registers a custom handler for progress updates.
+    pub fn set_update_handler(
+        self,
+        update_handler: readstat_sys::readstat_update_handler,
+    ) -> Result<Self, ReadStatError> {
+        let error =
+            unsafe { readstat_sys::readstat_set_update_handler(self.parser, update_handler) };
+        debug!("After setting update handler, error ==> {}", &error);
+        check_c_error(error as i32)?;
+        Ok(self)
+    }
+
+    /// Sets a custom I/O context pointer passed to all I/O handler callbacks.
+    pub fn set_io_ctx(self, io_ctx: *mut c_void) -> Result<Self, ReadStatError> {
+        let error = unsafe { readstat_sys::readstat_set_io_ctx(self.parser, io_ctx) };
+        debug!("After setting io ctx, error ==> {}", &error);
+        check_c_error(error as i32)?;
+        Ok(self)
+    }
+
     /// Parses a `.sas7bdat` file, invoking registered callbacks as data is read.
     ///
     /// Returns the raw ReadStat error code. Use [`check_c_error`](crate::err::check_c_error)


### PR DESCRIPTION
Enable parsing .sas7bdat data from &[u8] buffers instead of only from
file paths. This leverages ReadStat's existing custom I/O handler API
by implementing buffer-backed open/close/seek/read callbacks in Rust.

Key changes:
- Expose ReadStat I/O handler registration functions via bindgen
- Add I/O handler setter methods to ReadStatParser
- New rs_buffer_io module with ReadStatBufferCtx and extern C callbacks
- Add read_metadata_from_bytes() and read_data_from_bytes() methods
- 10 integration tests verifying bytes-based reading matches file-based

This unlocks future WASM compilation (no filesystem needed), cloud
storage streaming, HTTP upload processing, and in-memory testing.

https://claude.ai/code/session_01LhAVAAtqArJ5jawksY7vkW