### PR TITLE
Add Windows AddressSanitizer CI job and fix MSVC sanitizer flags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -374,3 +374,35 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Run tests with AddressSanitizer
         run: cargo +nightly test --workspace --lib --tests --bins --target aarch64-apple-darwin
+
+  asan-windows:
+    runs-on: windows-latest
+    env:
+      RUSTFLAGS: "-Zsanitizer=address"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: x86_64-pc-windows-msvc
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}\llvm
+          key: llvm-21.1.8
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "21.1.8"
+          directory: ${{ runner.temp }}\llvm
+          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+      - name: Run tests with AddressSanitizer
+        run: |
+            $env:LIBCLANG_PATH = "${{ runner.temp }}\llvm\bin"
+            cargo +nightly test --workspace --lib --tests --bins --target x86_64-pc-windows-msvc

--- a/crates/readstat-sys/build.rs
+++ b/crates/readstat-sys/build.rs
@@ -83,8 +83,13 @@ fn main() {
     // Uses a targeted env var so third-party sys crates (e.g. zstd-sys)
     // are not affected — global CFLAGS would break their linking.
     if env::var("READSTAT_SANITIZE_ADDRESS").is_ok() {
-        cc.flag("-fsanitize=address");
-        cc.flag("-fno-omit-frame-pointer");
+        if target.contains("windows-msvc") {
+            // MSVC cl.exe uses /fsanitize=address (forward-slash syntax)
+            cc.flag("/fsanitize=address");
+        } else {
+            cc.flag("-fsanitize=address");
+            cc.flag("-fno-omit-frame-pointer");
+        }
     }
 
     // Include iconv.h — Emscripten provides its own

--- a/docs/MEMORY_SAFETY.md
+++ b/docs/MEMORY_SAFETY.md
@@ -2,11 +2,11 @@
 
 # Memory Safety
 
-This project contains unsafe Rust code (FFI callbacks, pointer casts, memory-mapped I/O) and links against the vendored ReadStat C library. Three automated CI checks guard against memory errors.
+This project contains unsafe Rust code (FFI callbacks, pointer casts, memory-mapped I/O) and links against the vendored ReadStat C library. Four automated CI checks guard against memory errors.
 
 ## CI Jobs
 
-All three jobs run on every workflow dispatch and tag push, in parallel with the build jobs. Any memory error fails the job with a nonzero exit code.
+All four jobs run on every workflow dispatch and tag push, in parallel with the build jobs. Any memory error fails the job with a nonzero exit code.
 
 ### Miri (Rust undefined behavior)
 
@@ -38,13 +38,42 @@ Configuration:
 
 Configuration:
 - `RUSTFLAGS="-Zsanitizer=address"` — instruments Rust code only
-- The ReadStat C library is **not** instrumented on macOS because Apple Clang and Rust's LLVM have incompatible ASan runtimes (`___asan_version_mismatch_check_apple_clang_*` vs `___asan_version_mismatch_check_v8`)
+- The ReadStat C library is **not** instrumented on macOS because Apple Clang and Rust's LLVM have incompatible ASan runtimes — see [ASan Runtime Mismatch](#asan-runtime-mismatch-macos-and-windows) below
 - LeakSanitizer is not supported on macOS
+- Doctests excluded for the same reason as Linux
+
+### AddressSanitizer — Windows
+
+- **Platform**: Windows (x86_64, MSVC toolchain)
+- **Scope**: Full workspace — lib tests, integration tests, binary tests
+- **What it catches**: Buffer overflows, use-after-free, double-free in Rust code and at the FFI boundary
+
+Configuration:
+- `RUSTFLAGS="-Zsanitizer=address"` — instruments Rust code only
+- LLVM is installed for `libclang` (required by bindgen), same as the regular Windows build job
+- The ReadStat C library is **not** instrumented on Windows because MSVC's `cl.exe` ASan runtime (`/fsanitize=address`) is separate from the LLVM ASan runtime that Rust links against — see [ASan Runtime Mismatch](#asan-runtime-mismatch-macos-and-windows) below
+- LeakSanitizer is not supported on Windows
 - Doctests excluded for the same reason as Linux
 
 ## How `READSTAT_SANITIZE_ADDRESS` Works
 
-The `readstat-sys/build.rs` build script checks for the `READSTAT_SANITIZE_ADDRESS` environment variable. When set, it adds `-fsanitize=address` and `-fno-omit-frame-pointer` to the C compiler flags for the ReadStat library only. This is intentionally scoped — a global `CFLAGS` would instrument third-party sys crates (e.g., `zstd-sys`) causing linker failures.
+The `readstat-sys/build.rs` build script checks for the `READSTAT_SANITIZE_ADDRESS` environment variable. When set, it adds sanitizer flags to the C compiler flags for the ReadStat library only. This is intentionally scoped — a global `CFLAGS` would instrument third-party sys crates (e.g., `zstd-sys`) causing linker failures.
+
+The flags are platform-specific:
+- **Linux/macOS**: `-fsanitize=address -fno-omit-frame-pointer` (GCC/Clang syntax)
+- **Windows MSVC**: `/fsanitize=address` (MSVC syntax)
+
+Currently only the Linux CI job sets `READSTAT_SANITIZE_ADDRESS=1` because it is the only platform where both Rust and C use the same ASan runtime (LLVM's, via clang).
+
+## ASan Runtime Mismatch (macOS and Windows)
+
+Both macOS and Windows have an ASan runtime mismatch that prevents instrumenting the C code alongside Rust:
+
+**macOS**: Apple Clang is a fork of LLVM with its own ASan runtime versioning. When both Rust and the C library are instrumented, the linker sees two incompatible ASan runtimes and fails with `___asan_version_mismatch_check_apple_clang_*` vs `___asan_version_mismatch_check_v8`. A potential workaround is to install upstream LLVM via Homebrew (`brew install llvm`) and set `CC=/opt/homebrew/opt/llvm/bin/clang` so both the C code and Rust use the same LLVM ASan runtime. However, this is fragile — the Homebrew LLVM version must stay close to the LLVM version used by Rust nightly, which changes frequently.
+
+**Windows**: MSVC's `cl.exe` ships its own ASan runtime that is distinct from the LLVM ASan runtime Rust uses. Mixing `/fsanitize=address` (MSVC) with `-Zsanitizer=address` (Rust/LLVM) produces linker conflicts. A potential workaround is to use `clang-cl` (LLVM's MSVC-compatible driver) as the C compiler via `CC=clang-cl`, which would use the same LLVM ASan runtime as Rust. The LLVM installation in CI already includes `clang-cl.exe`, but this approach has not been validated and may have its own integration issues with MSVC headers and libraries.
+
+**Bottom line**: Linux is the only platform with full C + Rust ASan coverage. macOS and Windows provide Rust-only coverage, catching errors in Rust code and at the FFI boundary. This is sufficient because the ReadStat C library itself is third-party code with its own testing, and our primary concern is the Rust-side unsafe code that interacts with it.
 
 ## Running Locally
 
@@ -67,6 +96,12 @@ RUSTFLAGS="-Zsanitizer=address" \
 cargo +nightly test --workspace --lib --tests --bins --target aarch64-apple-darwin
 ```
 
+### ASan on Windows
+```powershell
+$env:RUSTFLAGS = "-Zsanitizer=address"
+cargo +nightly test --workspace --lib --tests --bins --target x86_64-pc-windows-msvc
+```
+
 ### Valgrind (Linux)
 
 For manual checks with full C library coverage, [valgrind](https://valgrind.org/) can also be used against debug test binaries:
@@ -83,4 +118,5 @@ valgrind ./target/debug/deps/parse_file_metadata_test-<hash>
 | Miri | Linux | Unit tests only | No (FFI excluded) | No |
 | ASan | Linux | Full workspace | Yes (instrumented) | Yes |
 | ASan | macOS | Full workspace | No (runtime mismatch) | No |
+| ASan | Windows | Full workspace | No (runtime mismatch) | No |
 | Valgrind | Linux (manual) | Full | Full | Yes |


### PR DESCRIPTION
Add a fourth memory safety CI job (asan-windows) that runs Rust-only
ASan on Windows MSVC, matching the macOS approach. Update build.rs to
use MSVC-style /fsanitize=address when READSTAT_SANITIZE_ADDRESS is set
on the windows-msvc target. Document the ASan runtime mismatch that
affects both macOS and Windows, including potential clang-cl workaround.

https://claude.ai/code/session_01V6saFKjaqVsJhHvYLomK6Z