### PR TITLE
Prepare readstat and readstat-cli 0.19.0 for crates.io release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Removed unnecessary `extern crate readstat_sys` from CLI binary
 - Added `version = "0.19.0"` to `readstat` dependency in `readstat-cli` for crates.io compatibility
 
+### crates.io release preparation
+- Renamed `iconv-sys` package to `readstat-iconv-sys` to avoid crates.io name conflict
+- Added `include` fields to `readstat-iconv-sys` and `readstat-sys` `Cargo.toml` to reduce crate package sizes
+- Changed `readme` paths in `readstat` and `readstat-cli` from `../../README.md` to per-crate `README.md`
+- Added `documentation` URL to `readstat-cli` `Cargo.toml`
+- Replaced `println!` with `log::warn!` for compression warnings in `WriteConfig` validation
+- Renamed `OutFormat` variants from `snake_case` to `PascalCase` (`csv` → `Csv`, `parquet` → `Parquet`, etc.)
+- Renamed `CliOutFormat` and `Reader` CLI enum variants to `PascalCase` (clap `ValueEnum` preserves lowercase CLI input)
+- Removed crate-level `#[allow(non_camel_case_types)]` from `readstat` library; added targeted `#[allow]` to C-mirroring enums
+- Added `#[must_use]` to all `ReadStatData` builder methods (`init`, `init_shared`, `set_no_progress`, etc.)
+- Changed `ReadStatMetadata` public fields from `c_int` to `i32` (`row_count`, `var_count`, `version`, `is64bit`)
+- Extracted `indicatif` progress bar from `readstat` library into `ProgressCallback` trait; CLI provides the `indicatif` implementation
+- Removed `indicatif` dependency from `readstat` library crate
+- Fixed clippy `doc_markdown` warnings (backtick `ReadStat` and other identifiers in doc comments)
+- Applied pedantic clippy auto-fixes
+
 ## [0.18.0]
 
 ### Added

--- a/crates/iconv-sys/Cargo.toml
+++ b/crates/iconv-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "iconv-sys"
+name = "readstat-iconv-sys"
 version = "0.3.0"
 authors = ["Curtis Alexander <calex@calex.org>"]
 edition = "2024"
@@ -9,11 +9,23 @@ homepage = "https://github.com/curtisalexander/readstat-rs"
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/curtisalexander/readstat-rs"
-documentation = "https://docs.rs/iconv-sys"
+documentation = "https://docs.rs/readstat-iconv-sys"
 keywords = ["iconv", "ffi", "bindings", "windows"]
 categories = ["external-ffi-bindings"]
 links = "iconv"
 build = "build.rs"
+include = [
+    "build.rs",
+    "src/**",
+    "wrapper.h",
+    "README.md",
+    "vendor/libiconv-win-build/include/**",
+    "vendor/libiconv-win-build/lib/**",
+    "vendor/libiconv-win-build/libcharset/**",
+    "vendor/libiconv-win-build/srclib/**",
+    "vendor/libiconv-win-build/COPYING*",
+    "vendor/libiconv-win-build/LICENSE.md",
+]
 
 [build-dependencies]
 bindgen = "0.72"

--- a/crates/iconv-sys/src/lib.rs
+++ b/crates/iconv-sys/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate compiles libiconv from a vendored git submodule on Windows and is a
 //! no-op on other platforms. It exists primarily to support [`readstat-sys`](https://docs.rs/readstat-sys),
-//! which needs iconv for character encoding conversion in the ReadStat C library.
+//! which needs iconv for character encoding conversion in the `ReadStat` C library.
 
 #![allow(clippy::redundant_static_lifetimes)]
 #![allow(dead_code)]

--- a/crates/readstat-cli/Cargo.toml
+++ b/crates/readstat-cli/Cargo.toml
@@ -8,7 +8,8 @@ description = "CLI for converting SAS binary files to other formats"
 homepage = "https://github.com/curtisalexander/readstat-rs"
 license = "MIT"
 repository = "https://github.com/curtisalexander/readstat-rs"
-readme = "../../README.md"
+readme = "README.md"
+documentation = "https://docs.rs/readstat-cli"
 keywords = ["sas", "sas7bdat", "arrow", "parquet", "readstat"]
 categories = ["command-line-utilities"]
 

--- a/crates/readstat-cli/src/cli.rs
+++ b/crates/readstat-cli/src/cli.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 /// 💾 Command-line tool for working with SAS binary files
 ///
-/// 🦀 Rust wrapper of ReadStat C library
+/// 🦀 Rust wrapper of `ReadStat` C library
 #[derive(Parser, Debug)]
 #[command(version)]
 #[command(propagate_version = true)]
@@ -124,27 +124,29 @@ pub enum ReadStatCliCommands {
     },
 }
 
-/// CLI output file format (with clap ValueEnum derive).
+/// CLI output file format (with clap `ValueEnum` derive).
+///
+/// Clap's `ValueEnum` derive converts `PascalCase` variants to lowercase
+/// for CLI input (e.g., `Csv` → `csv`).
 #[derive(Debug, Clone, Copy, ValueEnum)]
-#[allow(non_camel_case_types)]
 pub enum CliOutFormat {
     /// Comma-separated values.
-    csv,
+    Csv,
     /// Feather (Arrow IPC) format.
-    feather,
+    Feather,
     /// Newline-delimited JSON.
-    ndjson,
+    Ndjson,
     /// Apache Parquet columnar format.
-    parquet,
+    Parquet,
 }
 
 impl From<CliOutFormat> for OutFormat {
     fn from(f: CliOutFormat) -> Self {
         match f {
-            CliOutFormat::csv => OutFormat::csv,
-            CliOutFormat::feather => OutFormat::feather,
-            CliOutFormat::ndjson => OutFormat::ndjson,
-            CliOutFormat::parquet => OutFormat::parquet,
+            CliOutFormat::Csv => OutFormat::Csv,
+            CliOutFormat::Feather => OutFormat::Feather,
+            CliOutFormat::Ndjson => OutFormat::Ndjson,
+            CliOutFormat::Parquet => OutFormat::Parquet,
         }
     }
 }
@@ -152,34 +154,36 @@ impl From<CliOutFormat> for OutFormat {
 impl fmt::Display for CliOutFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::csv => f.write_str("csv"),
-            Self::feather => f.write_str("feather"),
-            Self::ndjson => f.write_str("ndjson"),
-            Self::parquet => f.write_str("parquet"),
+            Self::Csv => f.write_str("csv"),
+            Self::Feather => f.write_str("feather"),
+            Self::Ndjson => f.write_str("ndjson"),
+            Self::Parquet => f.write_str("parquet"),
         }
     }
 }
 
 /// Strategy for reading SAS data into memory.
+///
+/// Clap's `ValueEnum` derive converts `PascalCase` variants to lowercase
+/// for CLI input (e.g., `Mem` → `mem`).
 #[derive(Debug, Clone, Copy, ValueEnum)]
-#[allow(non_camel_case_types)]
 pub enum Reader {
     /// Read all data into memory at once.
-    mem,
+    Mem,
     /// Stream data in chunks (default, lower memory usage).
-    stream,
+    Stream,
 }
 
 impl fmt::Display for Reader {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::mem => f.write_str("mem"),
-            Self::stream => f.write_str("stream"),
+            Self::Mem => f.write_str("mem"),
+            Self::Stream => f.write_str("stream"),
         }
     }
 }
 
-/// CLI Parquet compression algorithm (with clap ValueEnum derive).
+/// CLI Parquet compression algorithm (with clap `ValueEnum` derive).
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum CliParquetCompression {
     /// No compression.

--- a/crates/readstat-sys/Cargo.toml
+++ b/crates/readstat-sys/Cargo.toml
@@ -14,6 +14,14 @@ keywords = ["sas", "readstat", "ffi", "bindings"]
 categories = ["external-ffi-bindings"]
 links = "readstat"
 build = "build.rs"
+include = [
+    "build.rs",
+    "src/**",
+    "wrapper.h",
+    "README.md",
+    "vendor/ReadStat/src/**",
+    "vendor/ReadStat/LICENSE",
+]
 
 [build-dependencies]
 bindgen = "0.72"
@@ -23,4 +31,4 @@ cc = "1.2"
 libz-sys = "1.1"
 
 [target.'cfg(windows)'.dependencies]
-iconv-sys = { path = "../iconv-sys", version = "0.3.0" }
+readstat-iconv-sys = { path = "../iconv-sys", version = "0.3.0" }

--- a/crates/readstat-sys/src/lib.rs
+++ b/crates/readstat-sys/src/lib.rs
@@ -1,10 +1,10 @@
 //! Raw FFI bindings to the [ReadStat](https://github.com/WizardMac/ReadStat) C library.
 //!
 //! This crate provides auto-generated bindings via [`bindgen`](https://docs.rs/bindgen).
-//! It compiles the ReadStat C source files from a vendored git submodule and links
+//! It compiles the `ReadStat` C source files from a vendored git submodule and links
 //! against platform-specific iconv and zlib libraries.
 //!
-//! These bindings expose the **full** ReadStat API, including support for SAS (`.sas7bdat`,
+//! These bindings expose the **full** `ReadStat` API, including support for SAS (`.sas7bdat`,
 //! `.xpt`), SPSS (`.sav`, `.zsav`, `.por`), and Stata (`.dta`) file formats. However,
 //! the higher-level [`readstat`](https://docs.rs/readstat) crate currently only implements
 //! parsing and conversion for **SAS `.sas7bdat` files**.

--- a/crates/readstat-tests/tests/cli_data_parquet.rs
+++ b/crates/readstat-tests/tests/cli_data_parquet.rs
@@ -460,9 +460,7 @@ fn cars_to_parquet_with_compression_uncompressed_with_compression_level() {
         Some(ParquetCompression::Uncompressed),
         Some(5),
     ) {
-        cmd.assert()
-            .success()
-            .stdout(predicate::str::contains("Compression level is not required for compression=uncompressed, ignoring value of --compression-level"));
+        cmd.assert().success();
 
         tempfile.close().unwrap();
     }
@@ -549,9 +547,7 @@ fn cars_to_parquet_with_compression_snappy_with_compression_level() {
         Some(ParquetCompression::Snappy),
         Some(5),
     ) {
-        cmd.assert()
-            .success()
-            .stdout(predicate::str::contains("Compression level is not required for compression=snappy, ignoring value of --compression-level"));
+        cmd.assert().success();
 
         tempfile.close().unwrap();
     }
@@ -614,9 +610,7 @@ fn cars_to_parquet_with_compression_lz4raw_with_compression_level() {
         Some(ParquetCompression::Lz4Raw),
         Some(5),
     ) {
-        cmd.assert()
-            .success()
-            .stdout(predicate::str::contains("Compression level is not required for compression=lz4-raw, ignoring value of --compression-level"));
+        cmd.assert().success();
 
         tempfile.close().unwrap();
     }

--- a/crates/readstat-tests/tests/sql_query_test.rs
+++ b/crates/readstat-tests/tests/sql_query_test.rs
@@ -307,7 +307,7 @@ fn sql_stream_and_write() {
         "cars",
         "SELECT \"Brand\", \"Model\", \"EngineSize\" FROM cars WHERE \"EngineSize\" > 5.0",
         &out_path,
-        readstat::OutFormat::parquet,
+        readstat::OutFormat::Parquet,
         None,
         None,
     )

--- a/crates/readstat/Cargo.toml
+++ b/crates/readstat/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/curtisalexander/readstat-rs"
 license = "MIT"
 repository = "https://github.com/curtisalexander/readstat-rs"
 documentation = "https://docs.rs/readstat"
-readme = "../../README.md"
+readme = "README.md"
 keywords = ["sas", "sas7bdat", "arrow", "parquet", "readstat"]
 categories = ["parser-implementations", "science"]
 
@@ -63,7 +63,6 @@ version = "0.3"
 optional = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-indicatif = "0.18"
 memmap2 = "0.9"
 path_abs = "0.5"
 rayon = "1.11"

--- a/crates/readstat/benches/readstat_benchmarks.rs
+++ b/crates/readstat/benches/readstat_benchmarks.rs
@@ -173,7 +173,7 @@ fn bench_write_csv(c: &mut Criterion) {
     group.throughput(Throughput::Elements(rows as u64));
     group.bench_function("sequential", |b| {
         b.iter(|| {
-            let rsp_out = setup_output_path(&temp_dir, "cars.sas7bdat", readstat::OutFormat::csv);
+            let rsp_out = setup_output_path(&temp_dir, "cars.sas7bdat", readstat::OutFormat::Csv);
             let mut wtr = ReadStatWriter::new();
             wtr.write(black_box(&d), black_box(&rsp_out)).unwrap();
             wtr.finish(black_box(&d), black_box(&rsp_out)).unwrap();
@@ -221,7 +221,7 @@ fn bench_write_parquet_compression(c: &mut Criterion) {
                     let rsp_out = ReadStatPath::new(
                         input_path,
                         Some(output_path),
-                        Some(readstat::OutFormat::parquet),
+                        Some(readstat::OutFormat::Parquet),
                         true,
                         false,
                         *comp,
@@ -307,10 +307,10 @@ fn bench_write_formats(c: &mut Criterion) {
     group.throughput(Throughput::Elements(rows as u64));
 
     for format in &[
-        ("csv", readstat::OutFormat::csv),
-        ("parquet", readstat::OutFormat::parquet),
-        ("feather", readstat::OutFormat::feather),
-        ("ndjson", readstat::OutFormat::ndjson),
+        ("csv", readstat::OutFormat::Csv),
+        ("parquet", readstat::OutFormat::Parquet),
+        ("feather", readstat::OutFormat::Feather),
+        ("ndjson", readstat::OutFormat::Ndjson),
     ] {
         group.bench_with_input(
             BenchmarkId::from_parameter(format.0),
@@ -342,8 +342,8 @@ fn bench_end_to_end_conversion(c: &mut Criterion) {
     group.throughput(Throughput::Elements(rows as u64));
 
     for format in &[
-        ("csv", readstat::OutFormat::csv),
-        ("parquet", readstat::OutFormat::parquet),
+        ("csv", readstat::OutFormat::Csv),
+        ("parquet", readstat::OutFormat::Parquet),
     ] {
         group.bench_with_input(BenchmarkId::new("format", format.0), &format.1, |b, fmt| {
             b.iter(|| {

--- a/crates/readstat/src/cb.rs
+++ b/crates/readstat/src/cb.rs
@@ -1,6 +1,6 @@
-//! FFI callback functions invoked by the ReadStat C library during parsing.
+//! FFI callback functions invoked by the `ReadStat` C library during parsing.
 //!
-//! The ReadStat C parser uses a callback-driven architecture: as it reads a `.sas7bdat`
+//! The `ReadStat` C parser uses a callback-driven architecture: as it reads a `.sas7bdat`
 //! file, it invokes registered callbacks for metadata, variables, and values. Each
 //! callback receives a raw `*mut c_void` context pointer that is cast back to the
 //! appropriate Rust struct ([`ReadStatMetadata`](crate::ReadStatMetadata) or
@@ -19,12 +19,12 @@ use crate::{
     rs_var::{ReadStatVarFormatClass, ReadStatVarType, ReadStatVarTypeClass},
 };
 
-/// Return codes for ReadStat C callback functions.
+/// Return codes for `ReadStat` C callback functions.
 ///
 /// Mirrors the `readstat_handler_t` enum from the C API. Only `OK` and `ABORT`
 /// are currently used; `SKIP_VARIABLE` is included for completeness with the
 /// C API contract.
-#[allow(dead_code)]
+#[allow(dead_code, non_camel_case_types)]
 #[derive(Debug)]
 #[repr(C)]
 enum ReadStatHandler {
@@ -35,7 +35,7 @@ enum ReadStatHandler {
 
 // C callback functions
 
-/// FFI callback that extracts file-level metadata from the ReadStat C parser.
+/// FFI callback that extracts file-level metadata from the `ReadStat` C parser.
 ///
 /// Called once during parsing. Populates the [`ReadStatMetadata`] struct
 /// (accessed via the `ctx` pointer) with row/variable counts, encoding,
@@ -45,7 +45,7 @@ enum ReadStatHandler {
 ///
 /// - `metadata` must be a valid pointer to a `readstat_metadata_t` produced by the C parser.
 /// - `ctx` must be a valid pointer to a [`ReadStatMetadata`] instance that outlives this call.
-/// - This function must only be called by the ReadStat C library as a registered callback.
+/// - This function must only be called by the `ReadStat` C library as a registered callback.
 pub(crate) extern "C" fn handle_metadata(
     metadata: *mut readstat_sys::readstat_metadata_t,
     ctx: *mut c_void,
@@ -125,7 +125,7 @@ pub(crate) extern "C" fn handle_metadata(
     ReadStatHandler::READSTAT_HANDLER_OK as c_int
 }
 
-/// FFI callback that extracts per-variable metadata from the ReadStat C parser.
+/// FFI callback that extracts per-variable metadata from the `ReadStat` C parser.
 ///
 /// Called once for each variable (column) in the dataset. Populates a
 /// [`ReadStatVarMetadata`] entry in the [`ReadStatMetadata::vars`] map
@@ -135,7 +135,7 @@ pub(crate) extern "C" fn handle_metadata(
 ///
 /// - `variable` must be a valid pointer to a `readstat_variable_t` produced by the C parser.
 /// - `ctx` must be a valid pointer to a [`ReadStatMetadata`] instance that outlives this call.
-/// - This function must only be called by the ReadStat C library as a registered callback.
+/// - This function must only be called by the `ReadStat` C library as a registered callback.
 pub(crate) extern "C" fn handle_variable(
     index: c_int,
     variable: *mut readstat_sys::readstat_variable_t,
@@ -205,7 +205,7 @@ const DAY_SHIFT: i32 = 3653;
 /// SAS epoch to Unix epoch offset in seconds.
 const SEC_SHIFT: i64 = 315619200;
 
-/// Scale factor for rounding: 10^DECIMAL_PLACES, computed once.
+/// Scale factor for rounding: `10^DECIMAL_PLACES`, computed once.
 const ROUND_SCALE: f64 = 1e14;
 
 /// Rounds an f64 to [`DECIMAL_PLACES`] decimal places using pure arithmetic.
@@ -254,7 +254,7 @@ fn round_decimal_f32(v: f32) -> f32 {
 /// - `variable` must be a valid pointer to a `readstat_variable_t` produced by the C parser.
 /// - `value` must be a valid `readstat_value_t` produced by the C parser.
 /// - `ctx` must be a valid pointer to a [`ReadStatData`] instance that outlives this call.
-/// - This function must only be called by the ReadStat C library as a registered callback.
+/// - This function must only be called by the `ReadStat` C library as a registered callback.
 pub(crate) extern "C" fn handle_value(
     obs_index: c_int,
     variable: *mut readstat_sys::readstat_variable_t,
@@ -449,7 +449,7 @@ pub(crate) extern "C" fn handle_value(
         if let Some(trp) = &d.total_rows_processed {
             trp.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
-    };
+    }
 
     ReadStatHandler::READSTAT_HANDLER_OK as c_int
 }

--- a/crates/readstat/src/err.rs
+++ b/crates/readstat/src/err.rs
@@ -1,17 +1,18 @@
 //! Error types for the readstat crate.
 //!
-//! [`ReadStatCError`] maps the 41 error codes from the ReadStat C library to Rust
+//! [`ReadStatCError`] maps the 41 error codes from the `ReadStat` C library to Rust
 //! enum variants. [`ReadStatError`] is the main error type, wrapping C library errors
 //! alongside Arrow, Parquet, I/O, and other failure modes.
 
 use num_derive::FromPrimitive;
 
-/// Error codes returned by the ReadStat C library.
+/// Error codes returned by the `ReadStat` C library.
 ///
 /// Each variant maps directly to a `readstat_error_t` value. A value of
 /// [`READSTAT_OK`](ReadStatCError::READSTAT_OK) indicates success; all other
 /// variants represent specific failure conditions.
 #[derive(Debug, FromPrimitive)]
+#[allow(non_camel_case_types)]
 pub enum ReadStatCError {
     /// Operation completed successfully.
     READSTAT_OK = 0,
@@ -99,11 +100,11 @@ pub enum ReadStatCError {
 
 /// The main error type for the readstat crate.
 ///
-/// Wraps errors from the ReadStat C library, Arrow/Parquet processing,
+/// Wraps errors from the `ReadStat` C library, Arrow/Parquet processing,
 /// I/O operations, and other subsystems into a single error enum.
 #[derive(Debug, thiserror::Error)]
 pub enum ReadStatError {
-    /// Error from the ReadStat C library.
+    /// Error from the `ReadStat` C library.
     #[error("ReadStat C library error: {0:?}")]
     CLibrary(ReadStatCError),
 
@@ -146,11 +147,6 @@ pub enum ReadStatError {
     #[error("{0}")]
     Rayon(#[from] rayon::ThreadPoolBuildError),
 
-    /// Progress bar template error.
-    #[cfg(not(target_arch = "wasm32"))]
-    #[error("{0}")]
-    IndicatifTemplate(#[from] indicatif::style::TemplateError),
-
     /// Null byte found in a string intended for C FFI.
     #[error("{0}")]
     NulError(#[from] std::ffi::NulError),
@@ -174,7 +170,7 @@ pub enum ReadStatError {
     Other(String),
 }
 
-/// Check a readstat C error code, returning Ok(()) for READSTAT_OK
+/// Check a readstat C error code, returning Ok(()) for `READSTAT_OK`
 /// or an appropriate error variant otherwise.
 pub(crate) fn check_c_error(code: i32) -> Result<(), ReadStatError> {
     use num_traits::FromPrimitive;

--- a/crates/readstat/src/formats.rs
+++ b/crates/readstat/src/formats.rs
@@ -2,7 +2,7 @@
 //!
 //! SAS variables carry format strings (e.g. `DATE9`, `DATETIME22.3`, `TIME8`) that
 //! determine how raw numeric values should be interpreted. This module classifies
-//! those format strings into [`ReadStatVarFormatClass`] variants (Date, DateTime,
+//! those format strings into [`ReadStatVarFormatClass`] variants (Date, `DateTime`,
 //! Time, and their sub-second precision variants), enabling correct Arrow type mapping.
 //!
 //! Supports all 118+ SAS date/time/datetime formats including ISO 8601 variants,

--- a/crates/readstat/src/lib.rs
+++ b/crates/readstat/src/lib.rs
@@ -6,7 +6,7 @@
 //! format for output as CSV, Feather (Arrow IPC), NDJSON, or Parquet.
 //!
 //! **Note:** While the underlying [`readstat-sys`](https://docs.rs/readstat-sys) crate
-//! exposes bindings for all formats supported by ReadStat (SAS, SPSS, Stata),
+//! exposes bindings for all formats supported by `ReadStat` (SAS, SPSS, Stata),
 //! this crate currently only implements parsing and conversion for **SAS `.sas7bdat` files**.
 //!
 //! # Data Pipeline
@@ -53,7 +53,7 @@
 //! # }
 //! ```
 //!
-//! ## Read all data into Arrow RecordBatch
+//! ## Read all data into Arrow `RecordBatch`
 //!
 //! Parse the entire file into a single Arrow [`RecordBatch`](arrow_array::RecordBatch).
 //! Best for smaller files that fit comfortably in memory.
@@ -97,7 +97,7 @@
 //! let rsp = ReadStatPath::new("data.sas7bdat".into())?;
 //! let wc = WriteConfig::new(
 //!     Some("output.parquet".into()),
-//!     Some(OutFormat::parquet),
+//!     Some(OutFormat::Parquet),
 //!     false, // overwrite
 //!     None,  // compression (defaults to Snappy for Parquet)
 //!     None,  // compression_level
@@ -191,7 +191,7 @@
 //! # }
 //! ```
 //!
-//! ## Convert RecordBatch to in-memory bytes
+//! ## Convert `RecordBatch` to in-memory bytes
 //!
 //! Serialize a parsed [`RecordBatch`](arrow_array::RecordBatch) directly to
 //! in-memory bytes without writing to a file. Useful for HTTP responses,
@@ -233,7 +233,7 @@
 //! - [`WriteConfig`] — Output configuration (path, format, compression)
 //! - [`ReadStatMetadata`] — File-level metadata (row/var counts, encoding, Arrow schema)
 //! - [`ReadStatData`] — Parsed row data, convertible to Arrow [`RecordBatch`](arrow_array::RecordBatch)
-//! - [`ReadStatVarFormatClass`] — SAS format classification (Date, DateTime, Time variants)
+//! - [`ReadStatVarFormatClass`] — SAS format classification (Date, `DateTime`, Time variants)
 //! - [`ReadStatWriter`] — Writes Arrow batches to the configured output format
 //!
 //! # Features
@@ -249,10 +249,10 @@
 //! | `sql` | SQL | Query data with SQL via DataFusion (not enabled by default) |
 
 #![warn(missing_docs)]
-#![allow(non_camel_case_types)]
 
 pub use common::build_offsets;
 pub use err::{ReadStatCError, ReadStatError};
+pub use progress::ProgressCallback;
 pub use rs_data::ReadStatData;
 pub use rs_metadata::{ReadStatCompress, ReadStatEndian, ReadStatMetadata, ReadStatVarMetadata};
 pub use rs_path::ReadStatPath;
@@ -276,6 +276,7 @@ mod cb;
 mod common;
 mod err;
 mod formats;
+mod progress;
 mod rs_buffer_io;
 mod rs_data;
 mod rs_metadata;

--- a/crates/readstat/src/progress.rs
+++ b/crates/readstat/src/progress.rs
@@ -1,0 +1,35 @@
+//! Progress reporting trait for parsing feedback.
+//!
+//! The [`ProgressCallback`] trait allows callers to receive progress updates
+//! during data parsing without coupling the library to any specific progress
+//! bar implementation. The CLI crate provides an `indicatif`-based implementation.
+
+/// Trait for receiving progress updates during data parsing.
+///
+/// Implement this trait to display a progress bar, log progress, or perform
+/// any other action when the parser makes forward progress.
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use readstat::ProgressCallback;
+///
+/// struct LogProgress;
+///
+/// impl ProgressCallback for LogProgress {
+///     fn inc(&self, n: u64) {
+///         println!("Processed {n} more rows");
+///     }
+///     fn parsing_started(&self, path: &str) {
+///         println!("Parsing file: {path}");
+///     }
+/// }
+/// ```
+pub trait ProgressCallback: Send + Sync {
+    /// Called to report that `n` additional rows have been processed.
+    fn inc(&self, n: u64);
+
+    /// Called when parsing begins for the file at `path`.
+    fn parsing_started(&self, path: &str);
+}

--- a/crates/readstat/src/rs_buffer_io.rs
+++ b/crates/readstat/src/rs_buffer_io.rs
@@ -1,7 +1,7 @@
 //! Buffer-based I/O handlers for parsing SAS files from in-memory byte slices.
 //!
 //! Provides [`ReadStatBufferCtx`] and a set of `extern "C"` callback functions that
-//! implement the ReadStat I/O interface over a `&[u8]` buffer instead of a file.
+//! implement the `ReadStat` I/O interface over a `&[u8]` buffer instead of a file.
 //! This enables parsing `.sas7bdat` data without filesystem access — useful for
 //! WASM targets, cloud storage, HTTP uploads, and testing.
 
@@ -11,7 +11,7 @@ use std::ptr;
 use crate::err::ReadStatError;
 use crate::rs_parser::ReadStatParser;
 
-/// In-memory buffer context for ReadStat I/O callbacks.
+/// In-memory buffer context for `ReadStat` I/O callbacks.
 ///
 /// Wraps a borrowed byte slice and tracks the current read position.
 /// Passed as the `io_ctx` pointer to all I/O handler callbacks.
@@ -41,7 +41,7 @@ impl ReadStatBufferCtx {
         &mut self,
         parser: ReadStatParser,
     ) -> Result<ReadStatParser, ReadStatError> {
-        let ctx_ptr = self as *mut ReadStatBufferCtx as *mut c_void;
+        let ctx_ptr = std::ptr::from_mut::<ReadStatBufferCtx>(self) as *mut c_void;
         parser
             .set_open_handler(Some(buffer_open))
             .and_then(|p| p.set_close_handler(Some(buffer_close)))

--- a/crates/readstat/src/rs_parser.rs
+++ b/crates/readstat/src/rs_parser.rs
@@ -1,7 +1,7 @@
-//! Safe wrapper around the ReadStat C parser.
+//! Safe wrapper around the `ReadStat` C parser.
 //!
 //! [`ReadStatParser`] provides a builder-pattern API for configuring and invoking the
-//! ReadStat C library's `readstat_parser_t`. It manages the parser lifecycle (init/free)
+//! `ReadStat` C library's `readstat_parser_t`. It manages the parser lifecycle (init/free)
 //! via RAII and exposes methods for setting callback handlers, row limits/offsets,
 //! and triggering the actual `.sas7bdat` parse.
 
@@ -10,7 +10,7 @@ use std::os::raw::{c_char, c_long, c_void};
 
 use crate::err::{ReadStatError, check_c_error};
 
-/// Safe RAII wrapper around the ReadStat C parser (`readstat_parser_t`).
+/// Safe RAII wrapper around the `ReadStat` C parser (`readstat_parser_t`).
 ///
 /// Provides a builder-pattern API for configuring callbacks, row limits/offsets,
 /// and invoking the parse. The underlying C parser is freed on drop.
@@ -19,7 +19,7 @@ pub(crate) struct ReadStatParser {
 }
 
 impl ReadStatParser {
-    /// Allocates and initializes a new ReadStat C parser.
+    /// Allocates and initializes a new `ReadStat` C parser.
     pub(crate) fn new() -> Self {
         let parser: *mut readstat_sys::readstat_parser_t =
             unsafe { readstat_sys::readstat_parser_init() };
@@ -167,7 +167,7 @@ impl ReadStatParser {
 
     /// Parses a `.sas7bdat` file, invoking registered callbacks as data is read.
     ///
-    /// Returns the raw ReadStat error code. Use [`check_c_error`](crate::err::check_c_error)
+    /// Returns the raw `ReadStat` error code. Use [`check_c_error`](crate::err::check_c_error)
     /// to convert to a `Result`.
     pub(crate) fn parse_sas7bdat(
         &mut self,

--- a/crates/readstat/src/rs_path.rs
+++ b/crates/readstat/src/rs_path.rs
@@ -15,7 +15,7 @@ const IN_EXTENSIONS: &[&str] = &["sas7bdat", "sas7bcat"];
 /// Validated file path for SAS file input.
 ///
 /// Encapsulates the input `.sas7bdat` path (validated to exist with correct extension).
-/// The input path is also converted to a [`CString`] for passing to the ReadStat C library.
+/// The input path is also converted to a [`CString`] for passing to the `ReadStat` C library.
 #[derive(Debug, Clone)]
 pub struct ReadStatPath {
     /// Absolute path to the input `.sas7bdat` file.
@@ -61,7 +61,7 @@ impl ReadStatPath {
     fn validate_in_extension(path: &Path) -> Result<String, ReadStatError> {
         path.extension()
             .and_then(|e| e.to_str())
-            .map(|e| e.to_owned())
+            .map(std::borrow::ToOwned::to_owned)
             .map_or(
                 Err(ReadStatError::Other(format!(
                     "File {} does not have an extension!",

--- a/crates/readstat/src/rs_query.rs
+++ b/crates/readstat/src/rs_query.rs
@@ -224,7 +224,7 @@ pub fn write_sql_results(
     let schema = batches[0].schema();
 
     match format {
-        OutFormat::csv => {
+        OutFormat::Csv => {
             let f = std::fs::File::create(output_path)?;
             let mut writer = CsvWriterBuilder::new()
                 .with_header(true)
@@ -233,7 +233,7 @@ pub fn write_sql_results(
                 writer.write(batch)?;
             }
         }
-        OutFormat::feather => {
+        OutFormat::Feather => {
             let f = std::fs::File::create(output_path)?;
             let mut writer = IpcFileWriter::try_new(BufWriter::new(f), &schema)?;
             for batch in batches {
@@ -241,7 +241,7 @@ pub fn write_sql_results(
             }
             writer.finish()?;
         }
-        OutFormat::ndjson => {
+        OutFormat::Ndjson => {
             let f = std::fs::File::create(output_path)?;
             let mut writer = JsonLineDelimitedWriter::new(BufWriter::new(f));
             for batch in batches {
@@ -249,7 +249,7 @@ pub fn write_sql_results(
             }
             writer.finish()?;
         }
-        OutFormat::parquet => {
+        OutFormat::Parquet => {
             let f = std::fs::File::create(output_path)?;
             let codec = resolve_parquet_compression(compression, compression_level)?;
             let props = WriterProperties::builder()

--- a/crates/readstat/src/rs_var.rs
+++ b/crates/readstat/src/rs_var.rs
@@ -1,10 +1,10 @@
 //! Variable types and format classification for SAS data.
 //!
 //! [`ReadStatVarFormatClass`] classifies SAS format strings into semantic categories
-//! (Date, DateTime, Time, and their sub-second precision variants), which determines
+//! (Date, `DateTime`, Time, and their sub-second precision variants), which determines
 //! the Arrow data type used during conversion.
 //!
-//! [`ReadStatVarType`] and [`ReadStatVarTypeClass`] map ReadStat C type codes to Rust
+//! [`ReadStatVarType`] and [`ReadStatVarTypeClass`] map `ReadStat` C type codes to Rust
 //! enums, used during schema construction and builder allocation.
 
 use num_derive::FromPrimitive;
@@ -27,13 +27,13 @@ use serde::Serialize;
 pub enum ReadStatVarFormatClass {
     /// Date format (e.g. `DATE9`, `MMDDYY10`). Maps to Arrow `Date32`.
     Date,
-    /// DateTime format with second precision (e.g. `DATETIME22`).
+    /// `DateTime` format with second precision (e.g. `DATETIME22`).
     DateTime,
-    /// DateTime format with millisecond precision (e.g. `DATETIME22.3`).
+    /// `DateTime` format with millisecond precision (e.g. `DATETIME22.3`).
     DateTimeWithMilliseconds,
-    /// DateTime format with microsecond precision (e.g. `DATETIME22.6`).
+    /// `DateTime` format with microsecond precision (e.g. `DATETIME22.6`).
     DateTimeWithMicroseconds,
-    /// DateTime format with nanosecond precision (e.g. `DATETIME22.9`).
+    /// `DateTime` format with nanosecond precision (e.g. `DATETIME22.9`).
     DateTimeWithNanoseconds,
     /// Time format with second precision (e.g. `TIME8`).
     Time,
@@ -41,7 +41,7 @@ pub enum ReadStatVarFormatClass {
     TimeWithMicroseconds,
 }
 
-/// The storage type of a SAS variable, as reported by the ReadStat C library.
+/// The storage type of a SAS variable, as reported by the `ReadStat` C library.
 #[derive(Clone, Copy, Debug, FromPrimitive, Serialize)]
 pub enum ReadStatVarType {
     /// Variable-length string.

--- a/crates/readstat/src/rs_write.rs
+++ b/crates/readstat/src/rs_write.rs
@@ -267,23 +267,23 @@ impl ReadStatWriter {
     ) -> Result<(), ReadStatError> {
         match wc.format {
             #[cfg(feature = "csv")]
-            OutFormat::csv => {
+            OutFormat::Csv => {
                 self.print_finish_message(d, wc, in_path);
                 Ok(())
             }
             #[cfg(feature = "feather")]
-            OutFormat::feather => {
+            OutFormat::Feather => {
                 self.finish_feather()?;
                 self.print_finish_message(d, wc, in_path);
                 Ok(())
             }
             #[cfg(feature = "ndjson")]
-            OutFormat::ndjson => {
+            OutFormat::Ndjson => {
                 self.print_finish_message(d, wc, in_path);
                 Ok(())
             }
             #[cfg(feature = "parquet")]
-            OutFormat::parquet => {
+            OutFormat::Parquet => {
                 self.finish_parquet()?;
                 self.print_finish_message(d, wc, in_path);
                 Ok(())
@@ -363,7 +363,7 @@ impl ReadStatWriter {
     pub fn write(&mut self, d: &ReadStatData, wc: &WriteConfig) -> Result<(), ReadStatError> {
         match wc.format {
             #[cfg(feature = "csv")]
-            OutFormat::csv => {
+            OutFormat::Csv => {
                 if wc.out_path.is_none() {
                     if self.wrote_header {
                         self.write_data_to_stdout(d)
@@ -376,11 +376,11 @@ impl ReadStatWriter {
                 }
             }
             #[cfg(feature = "feather")]
-            OutFormat::feather => self.write_data_to_feather(d, wc),
+            OutFormat::Feather => self.write_data_to_feather(d, wc),
             #[cfg(feature = "ndjson")]
-            OutFormat::ndjson => self.write_data_to_ndjson(d, wc),
+            OutFormat::Ndjson => self.write_data_to_ndjson(d, wc),
             #[cfg(feature = "parquet")]
-            OutFormat::parquet => self.write_data_to_parquet(d, wc),
+            OutFormat::Parquet => self.write_data_to_parquet(d, wc),
             #[allow(unreachable_patterns)]
             _ => Err(ReadStatError::Other(format!(
                 "Output format {:?} is not enabled. Enable the corresponding feature flag.",
@@ -555,11 +555,6 @@ impl ReadStatWriter {
 
     #[cfg(feature = "csv")]
     fn write_data_to_stdout(&mut self, d: &ReadStatData) -> Result<(), ReadStatError> {
-        #[cfg(not(target_arch = "wasm32"))]
-        if let Some(pb) = &d.pb {
-            pb.finish_and_clear();
-        }
-
         // writer setup
         if !self.wrote_start {
             self.wtr = Some(ReadStatWriterFormat::CsvStdout(stdout()));
@@ -584,11 +579,6 @@ impl ReadStatWriter {
 
     #[cfg(feature = "csv")]
     fn write_header_to_stdout(&mut self, d: &ReadStatData) -> Result<(), ReadStatError> {
-        #[cfg(not(target_arch = "wasm32"))]
-        if let Some(pb) = &d.pb {
-            pb.finish_and_clear();
-        }
-
         let vars: Vec<String> = d.vars.values().map(|m| m.var_name.clone()).collect();
 
         println!("{}", vars.join(","));


### PR DESCRIPTION
- Rename iconv-sys package to readstat-iconv-sys to avoid crates.io name conflict
- Add include fields to readstat-iconv-sys and readstat-sys for smaller packages
- Fix readme paths and add documentation URL for readstat-cli
- Replace println! with log::warn! for library compression warnings
- Rename OutFormat/CliOutFormat/Reader variants to PascalCase
- Remove crate-level #[allow(non_camel_case_types)]; add targeted allows
- Add #[must_use] to ReadStatData builder methods
- Change ReadStatMetadata public fields from c_int to i32
- Extract indicatif into ProgressCallback trait; remove indicatif from library
- Fix clippy doc_markdown warnings and apply pedantic auto-fixes
- Add version = "0.19.0" to readstat dependency in readstat-cli
- Update ARCHITECTURE.md and CHANGELOG.md

https://claude.ai/code/session_01JsUMYEJh4LgL3wKVPUS3aP