### PR TITLE
Use force-url for Windows ASAN LLVM install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -413,6 +413,7 @@ jobs:
           version: ${{ steps.llvm-version.outputs.full }}
           directory: ${{ runner.temp }}\llvm
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+          force-url: https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ steps.llvm-version.outputs.full }}/LLVM-${{ steps.llvm-version.outputs.full }}-win64.exe
       - name: Run tests with AddressSanitizer
         run: |
             $env:LIBCLANG_PATH = "${{ runner.temp }}\llvm\bin"


### PR DESCRIPTION
The KyleMayes/install-llvm-action asset list doesn't include LLVM 22.1.0 for Windows yet. Bypass the known-assets check by downloading the installer directly from the official LLVM GitHub release using the dynamically detected version.