### PR TITLE
Add experimental full C+Rust ASAN CI job for Windows (Option 2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -422,3 +422,58 @@ jobs:
             $env:LIBCLANG_PATH = "${{ runner.temp }}\llvm\bin"
             $env:PATH = "${{ steps.asan-rt.outputs.dir }};$env:PATH"
             cargo +nightly test --workspace --lib --tests --bins --target x86_64-pc-windows-msvc
+
+  # Option 2: Full Rust + C ASAN instrumentation on Windows.
+  # Both Rust and MSVC's cl.exe use the same MSVC ASAN runtime, so full
+  # instrumentation SHOULD work. Marked continue-on-error because this is
+  # experimental — no one has publicly documented this combination working.
+  # See docs/WINDOWS_MEMORY_SAFETY_RESEARCH.md for details.
+  asan-windows-full:
+    runs-on: windows-latest
+    continue-on-error: true
+    env:
+      RUSTFLAGS: "-Zsanitizer=address"
+      READSTAT_SANITIZE_ADDRESS: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: x86_64-pc-windows-msvc
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+      # LLVM is needed only for libclang (bindgen).
+      # The ASAN runtime comes from Visual Studio (MSVC), not from this LLVM install.
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}\llvm
+          key: llvm-21.1.8
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "21.1.8"
+          directory: ${{ runner.temp }}\llvm
+          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+      - name: Find MSVC ASAN runtime
+        id: asan-rt
+        shell: pwsh
+        run: |
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" `
+            -latest -property installationPath
+          $msvcRoot = Join-Path $vsPath "VC\Tools\MSVC"
+          $msvcVer = (Get-ChildItem $msvcRoot | Sort-Object Name -Descending | Select-Object -First 1).Name
+          $asanDir = Join-Path $msvcRoot $msvcVer "bin" "Hostx64" "x64"
+          $asanDll = Join-Path $asanDir "clang_rt.asan_dynamic-x86_64.dll"
+          if (!(Test-Path $asanDll)) { throw "ASAN runtime not found at $asanDll" }
+          Write-Host "Found ASAN runtime: $asanDll"
+          echo "dir=$asanDir" >> $env:GITHUB_OUTPUT
+      - name: Run tests with AddressSanitizer (full C+Rust)
+        run: |
+            $env:LIBCLANG_PATH = "${{ runner.temp }}\llvm\bin"
+            $env:PATH = "${{ steps.asan-rt.outputs.dir }};$env:PATH"
+            cargo +nightly test --workspace --lib --tests --bins --target x86_64-pc-windows-msvc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - API server examples: Rust/Axum and Python/FastAPI (#127)
 - API usage examples to `readstat` crate rustdoc (#130)
 - Windows AddressSanitizer CI job and MSVC sanitizer flags (#128)
+- Experimental `asan-windows-full` CI job — instruments both Rust and ReadStat C code with ASAN on Windows using the shared MSVC runtime (`continue-on-error: true` while validating)
 - Plan document for numeric type narrowing (#129)
 
 ### Changed

--- a/docs/WINDOWS_MEMORY_SAFETY_RESEARCH.md
+++ b/docs/WINDOWS_MEMORY_SAFETY_RESEARCH.md
@@ -444,23 +444,21 @@ C+Rust coverage) plus Miri for memory safety.
 
 Based on this research, here is a recommended tiered approach:
 
-### Tier 1 (Do now): Simplify ASAN to Rust-only (Option 1)
+### Tier 1 (Done): Simplify ASAN to Rust-only (Option 1) ✅
 
-Fix the current CI job by removing the LLVM version chasing and ASAN DLL path
-manipulation. Just use Rust's ASAN with the MSVC runtime that's already on the
-GitHub Actions runner. This eliminates the maintenance burden while still
-catching Rust-side memory errors and FFI boundary issues.
+Implemented as the `asan-windows` CI job. Removed the LLVM version chasing and
+ASAN DLL path manipulation. Uses Rust's ASAN with the MSVC runtime already on
+the GitHub Actions runner, with a pinned LLVM version for `LIBCLANG_PATH`
+(bindgen) only.
 
-The LLVM install is still needed for `LIBCLANG_PATH` (bindgen), but we can pin
-it to a specific version like the `build-win` job does — no need to match Rust
-nightly's LLVM version.
+### Tier 2 (In progress): Attempt full Rust + C ASAN (Option 2) 🧪
 
-### Tier 2 (Try next): Attempt full Rust + C ASAN (Option 2)
-
-Since Rust and MSVC share the same ASAN runtime on Windows, full instrumentation
-SHOULD work. Try enabling `READSTAT_SANITIZE_ADDRESS=1` with the simplified
-setup. If linker conflicts arise, try `-Zexternal-clangrt`. This would give
-Windows the same coverage as Linux.
+Implemented as the `asan-windows-full` CI job with `continue-on-error: true`
+(experimental). Sets `READSTAT_SANITIZE_ADDRESS=1` to instrument the ReadStat C
+library with `/fsanitize=address` via MSVC's `cl.exe`. Since Rust and MSVC share
+the same ASAN runtime, this should work without runtime conflicts. If linker
+conflicts arise, the next step is to try adding `-Zexternal-clangrt` to
+RUSTFLAGS.
 
 ### Tier 3 (Complement): Add cargo-careful (Option 3)
 


### PR DESCRIPTION
Adds asan-windows-full job that instruments both Rust and ReadStat C code with AddressSanitizer using the shared MSVC runtime. Marked continue-on-error while validating this untested combination.