### PR TITLE
Resolve all clippy pedantic warnings for crates.io readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Variable metadata parsing in SQL Explorer (#138)
 - Windows ASAN CI: pinned LLVM for bindgen only and added MSVC ASan runtime DLL to PATH via `vswhere.exe` to fix `STATUS_DLL_NOT_FOUND` at test time
 - Suppressed `improper_ctypes` warning in `readstat-iconv-sys` from bindgen-generated SIMD intrinsic bindings
+- Resolved all `clippy::pedantic` warnings across the workspace (zero warnings with `-W clippy::all -W clippy::pedantic`)
+- Fixed `ptr_as_ptr` lints in `readstat` library (`.cast::<i8>()` instead of `as *const i8`)
+- Fixed `uninlined_format_args` in library tests and benchmarks
+- Suppressed bindgen-generated lint noise (`missing_safety_doc`, `useless_transmute`, `ptr_offset_with_cast`) in `-sys` crates
+- Added pedantic clippy `#![allow]` blocks to all integration test files for test-acceptable patterns (`float_cmp`, `cast_sign_loss`, etc.)
+- Replaced `String::from("")` with `String::new()` across test crate
+- Added missing date to CHANGELOG version 0.18.0
 
 ### crates.io release preparation
 - Renamed `iconv-sys` package to `readstat-iconv-sys` to avoid crates.io name conflict (#136)
@@ -45,7 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed clippy `doc_markdown` warnings (backtick `ReadStat` and other identifiers in doc comments)
 - Applied pedantic clippy auto-fixes
 
-## [0.18.0]
+## [0.18.0] - 2026-02-20
 
 ### Added
 - DataFusion SQL query support behind `sql` feature flag

--- a/crates/readstat-iconv-sys/src/lib.rs
+++ b/crates/readstat-iconv-sys/src/lib.rs
@@ -4,6 +4,11 @@
 //! no-op on other platforms. It exists primarily to support [`readstat-sys`](https://docs.rs/readstat-sys),
 //! which needs iconv for character encoding conversion in the `ReadStat` C library.
 
+// Auto-generated bindgen code — suppress lints from generated bindings
+#![allow(clippy::pedantic)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::ptr_offset_with_cast)]
+#![allow(clippy::useless_transmute)]
 #![allow(clippy::redundant_static_lifetimes)]
 #![allow(dead_code)]
 #![allow(deref_nullptr)]

--- a/crates/readstat-sys/src/lib.rs
+++ b/crates/readstat-sys/src/lib.rs
@@ -12,8 +12,11 @@
 //! Most users should depend on the higher-level [`readstat`](https://docs.rs/readstat)
 //! crate instead of using these bindings directly.
 
-// Auto-generated bindgen code — suppress all pedantic lints
+// Auto-generated bindgen code — suppress lints from generated bindings
 #![allow(clippy::pedantic)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::ptr_offset_with_cast)]
+#![allow(clippy::useless_transmute)]
 #![allow(dead_code)]
 #![allow(deref_nullptr)]
 #![allow(non_upper_case_globals)]

--- a/crates/readstat-tests/tests/arrow_migration_test.rs
+++ b/crates/readstat-tests/tests/arrow_migration_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 /// Tests to verify the arrow2 -> arrow migration correctness.
 /// These tests ensure that the migration from arrow2 to the arrow crate
 /// does not introduce any data integrity issues.
@@ -26,7 +36,7 @@ fn init_all_types() -> (ReadStatPath, ReadStatMetadata, ReadStatData) {
     (rsp, md, d)
 }
 
-/// Test: Verify RecordBatch structure is correctly created
+/// Test: Verify `RecordBatch` structure is correctly created
 #[test]
 fn migration_record_batch_structure() {
     let (rsp, md, mut d) = init_all_types();
@@ -364,7 +374,7 @@ fn migration_timestamp_values() {
     );
 }
 
-/// Test: Verify Arc<Schema> is properly shared in RecordBatch
+/// Test: Verify `Arc<Schema>` is properly shared in `RecordBatch`
 #[test]
 fn migration_schema_arc_sharing() {
     let (rsp, _md, mut d) = init_all_types();
@@ -472,7 +482,7 @@ fn migration_larger_dataset() {
     }
 }
 
-/// Test: Verify metadata skip_row_count functionality
+/// Test: Verify metadata `skip_row_count` functionality
 #[test]
 fn migration_metadata_skip_row_count() {
     let rsp = common::setup_path("all_types.sas7bdat").unwrap();
@@ -505,7 +515,7 @@ fn migration_metadata_skip_row_count() {
     assert_eq!(md_skip.row_count, 1, "Skip metadata should report 1 row");
 }
 
-/// Test: Verify RecordBatch can be cloned (important for data sharing)
+/// Test: Verify `RecordBatch` can be cloned (important for data sharing)
 #[test]
 fn migration_record_batch_clone() {
     let (rsp, _md, mut d) = init_all_types();

--- a/crates/readstat-tests/tests/bytes_reading_test.rs
+++ b/crates/readstat-tests/tests/bytes_reading_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::DataType;
 use common::ExpectedMetadata;
 

--- a/crates/readstat-tests/tests/cli.rs
+++ b/crates/readstat-tests/tests/cli.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::PathBuf;
@@ -25,12 +35,11 @@ fn readstat_cmd() -> Command {
 }
 
 #[test]
-fn cli_file_does_not_exist() -> Result<(), Box<dyn std::error::Error>> {
+fn cli_file_does_not_exist() {
     let mut cmd = readstat_cmd();
     cmd.arg("data").arg("tests/data/adataset.sas7bdat");
     cmd.assert().failure().stderr(
-        predicate::str::is_match(r#"^(Stopping with error: File)\s(.+)\s(does not exist!\n)$"#)
+        predicate::str::is_match(r"^(Stopping with error: File)\s(.+)\s(does not exist!\n)$")
             .unwrap(),
     );
-    Ok(())
 }

--- a/crates/readstat-tests/tests/cli_data_csv.rs
+++ b/crates/readstat-tests/tests/cli_data_csv.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use assert_cmd::Command;
 use assert_fs::NamedTempFile;
 use predicates::prelude::*;
@@ -42,14 +52,14 @@ const EXPECTED_COLUMNS: &[&str] = &[
     "Hybrid",
 ];
 
-/// Read a CSV file and return (header_fields, data_row_count).
+/// Read a CSV file and return (`header_fields`, `data_row_count`).
 fn read_csv_info(path: &std::path::Path) -> (Vec<String>, usize) {
     let f = std::fs::File::open(path).expect("failed to open CSV file");
     let reader = BufReader::new(f);
     let mut lines = reader.lines();
 
     let header_line = lines.next().expect("CSV file is empty").unwrap();
-    let header_fields: Vec<String> = header_line.split(',').map(|s| s.to_string()).collect();
+    let header_fields: Vec<String> = header_line.split(',').map(ToString::to_string).collect();
 
     let data_row_count = lines.count();
     (header_fields, data_row_count)
@@ -70,7 +80,7 @@ fn cars_to_csv() {
     ));
 
     let (header, data_rows) = read_csv_info(tempfile.path());
-    let expected: Vec<String> = EXPECTED_COLUMNS.iter().map(|s| s.to_string()).collect();
+    let expected: Vec<String> = EXPECTED_COLUMNS.iter().map(ToString::to_string).collect();
 
     assert_eq!(
         header, expected,
@@ -97,7 +107,7 @@ fn cars_to_csv_with_streaming() {
     ));
 
     let (header, data_rows) = read_csv_info(tempfile.path());
-    let expected: Vec<String> = EXPECTED_COLUMNS.iter().map(|s| s.to_string()).collect();
+    let expected: Vec<String> = EXPECTED_COLUMNS.iter().map(ToString::to_string).collect();
 
     assert_eq!(
         header, expected,
@@ -130,7 +140,7 @@ fn cars_to_csv_overwrite() {
     cmd.assert().success();
 
     let (header, data_rows) = read_csv_info(tempfile.path());
-    let expected: Vec<String> = EXPECTED_COLUMNS.iter().map(|s| s.to_string()).collect();
+    let expected: Vec<String> = EXPECTED_COLUMNS.iter().map(ToString::to_string).collect();
 
     assert_eq!(
         header, expected,

--- a/crates/readstat-tests/tests/cli_data_parquet.rs
+++ b/crates/readstat-tests/tests/cli_data_parquet.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use ::predicates::prelude::*;
 use assert_cmd::Command;
 use assert_fs::NamedTempFile;
@@ -674,7 +684,7 @@ fn cars_to_parquet_with_compression_gzip_level_10() {
         Some(10),
     ) {
         cmd.assert().failure().stderr(
-            predicate::str::is_match(r#"^Stopping with error: The compression level of \d+ is not a valid level for gzip compression. Instead, please use values between 0-9.\n?"#)
+            predicate::str::is_match(r"^Stopping with error: The compression level of \d+ is not a valid level for gzip compression. Instead, please use values between 0-9.\n?")
                 .unwrap(),
         );
 
@@ -692,7 +702,7 @@ fn cars_to_parquet_with_compression_gzip_level_55() {
         Some(55),
     ) {
         cmd.assert().failure().stderr(
-            predicate::str::is_match(r#"^error: invalid value '\d+' for '--compression-level <COMPRESSION_LEVEL>': \d+ is not in 0..=22\n?"#)
+            predicate::str::is_match(r"^error: invalid value '\d+' for '--compression-level <COMPRESSION_LEVEL>': \d+ is not in 0..=22\n?")
                 .unwrap(),
         );
 
@@ -758,7 +768,7 @@ fn cars_to_parquet_with_compression_brotli_level_12() {
         Some(12),
     ) {
         cmd.assert().failure().stderr(
-            predicate::str::is_match(r#"^Stopping with error: The compression level of \d+ is not a valid level for brotli compression. Instead, please use values between 0-11.\n?"#)
+            predicate::str::is_match(r"^Stopping with error: The compression level of \d+ is not a valid level for brotli compression. Instead, please use values between 0-11.\n?")
                 .unwrap(),
         );
 
@@ -776,7 +786,7 @@ fn cars_to_parquet_with_compression_brotli_level_55() {
         Some(55),
     ) {
         cmd.assert().failure().stderr(
-            predicate::str::is_match(r#"^error: invalid value '\d+' for '--compression-level <COMPRESSION_LEVEL>': \d+ is not in 0..=22\n?"#)
+            predicate::str::is_match(r"^error: invalid value '\d+' for '--compression-level <COMPRESSION_LEVEL>': \d+ is not in 0..=22\n?")
                 .unwrap(),
         );
 
@@ -866,7 +876,7 @@ fn cars_to_parquet_with_compression_zstd_level_55() {
         Some(55),
     ) {
         cmd.assert().failure().stderr(
-            predicate::str::is_match(r#"^error: invalid value '\d+' for '--compression-level <COMPRESSION_LEVEL>': \d+ is not in 0..=22\n?"#)
+            predicate::str::is_match(r"^error: invalid value '\d+' for '--compression-level <COMPRESSION_LEVEL>': \d+ is not in 0..=22\n?")
                 .unwrap(),
         );
 

--- a/crates/readstat-tests/tests/column_select_test.rs
+++ b/crates/readstat-tests/tests/column_select_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::DataType;
 use arrow_array::{Array, Float64Array, StringArray};
 use readstat::{ReadStatData, ReadStatMetadata};

--- a/crates/readstat-tests/tests/common/mod.rs
+++ b/crates/readstat-tests/tests/common/mod.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![allow(clippy::cast_sign_loss)]
 
 use arrow::datatypes::DataType;
 use arrow_array::{
@@ -23,7 +24,7 @@ where
     readstat::ReadStatPath::new(sas_path)
 }
 
-/// Reads a dataset fully: path -> metadata -> data -> RecordBatch.
+/// Reads a dataset fully: path -> metadata -> data -> `RecordBatch`.
 ///
 /// Returns (path, metadata, data) with the batch already produced.
 pub fn setup_and_read(

--- a/crates/readstat-tests/tests/input_file_test.rs
+++ b/crates/readstat-tests/tests/input_file_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 mod common;
 
 #[test]

--- a/crates/readstat-tests/tests/lib.rs
+++ b/crates/readstat-tests/tests/lib.rs
@@ -1,1 +1,9 @@
-
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]

--- a/crates/readstat-tests/tests/mmap_reading_test.rs
+++ b/crates/readstat-tests/tests/mmap_reading_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use common::ExpectedMetadata;
 
 mod common;

--- a/crates/readstat-tests/tests/parallel_write_cli_test.rs
+++ b/crates/readstat-tests/tests/parallel_write_cli_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use assert_cmd::Command;
 use assert_fs::prelude::*;
 use std::path::PathBuf;

--- a/crates/readstat-tests/tests/parallel_write_test.rs
+++ b/crates/readstat-tests/tests/parallel_write_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow_array::{Array, Float64Array, RecordBatch};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use readstat::{ReadStatData, ReadStatMetadata, ReadStatWriter};

--- a/crates/readstat-tests/tests/parquet_labels_test.rs
+++ b/crates/readstat-tests/tests/parquet_labels_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use assert_cmd::Command;
 use assert_fs::NamedTempFile;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;

--- a/crates/readstat-tests/tests/parse_all_dates_test.rs
+++ b/crates/readstat-tests/tests/parse_all_dates_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::DataType;
 use readstat::{ReadStatData, ReadStatMetadata, ReadStatPath, ReadStatVarFormatClass};
 
@@ -66,10 +76,10 @@ fn parse_all_dates_metadata() {
     assert_eq!(md.var_count, 128);
 
     // table name
-    assert_eq!(md.table_name, String::from(""));
+    assert_eq!(md.table_name, String::new());
 
     // table label
-    assert_eq!(md.file_label, String::from(""));
+    assert_eq!(md.file_label, String::new());
 
     // file encoding
     assert_eq!(md.file_encoding, String::from("UTF-8"));

--- a/crates/readstat-tests/tests/parse_all_datetimes_test.rs
+++ b/crates/readstat-tests/tests/parse_all_datetimes_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::{DataType, TimeUnit};
 use readstat::{ReadStatData, ReadStatMetadata, ReadStatPath, ReadStatVarFormatClass};
 
@@ -67,10 +77,10 @@ fn parse_all_datetimes_metadata() {
     assert_eq!(md.var_count, 76);
 
     // table name
-    assert_eq!(md.table_name, String::from(""));
+    assert_eq!(md.table_name, String::new());
 
     // table label
-    assert_eq!(md.file_label, String::from(""));
+    assert_eq!(md.file_label, String::new());
 
     // file encoding
     assert_eq!(md.file_encoding, String::from("UTF-8"));

--- a/crates/readstat-tests/tests/parse_all_times_test.rs
+++ b/crates/readstat-tests/tests/parse_all_times_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::{DataType, TimeUnit};
 use readstat::{ReadStatData, ReadStatMetadata, ReadStatPath, ReadStatVarFormatClass};
 
@@ -67,10 +77,10 @@ fn parse_all_times_metadata() {
     assert_eq!(md.var_count, 38);
 
     // table name
-    assert_eq!(md.table_name, String::from(""));
+    assert_eq!(md.table_name, String::new());
 
     // table label
-    assert_eq!(md.file_label, String::from(""));
+    assert_eq!(md.file_label, String::new());
 
     // file encoding
     assert_eq!(md.file_encoding, String::from("UTF-8"));

--- a/crates/readstat-tests/tests/parse_all_types_test.rs
+++ b/crates/readstat-tests/tests/parse_all_types_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::{DataType, TimeUnit};
 use arrow_array::Array;
 use chrono::{NaiveDate, NaiveTime, TimeZone, Utc};

--- a/crates/readstat-tests/tests/parse_cars_md_test.rs
+++ b/crates/readstat-tests/tests/parse_cars_md_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::DataType;
 use arrow_array::Array;
 use common::ExpectedMetadata;

--- a/crates/readstat-tests/tests/parse_hasmissing_test.rs
+++ b/crates/readstat-tests/tests/parse_hasmissing_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::DataType;
 use arrow_array::Array;
 use common::ExpectedMetadata;

--- a/crates/readstat-tests/tests/parse_intel_test.rs
+++ b/crates/readstat-tests/tests/parse_intel_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::DataType;
 use arrow_array::Float64Array;
 use readstat::{ReadStatData, ReadStatMetadata, ReadStatPath};
@@ -31,7 +41,7 @@ fn parse_intel_metadata() {
     assert_eq!(md.table_name, String::from("INTEL"));
 
     // table label
-    assert_eq!(md.file_label, String::from(""));
+    assert_eq!(md.file_label, String::new());
 
     // file encoding
     assert_eq!(md.file_encoding, String::from("WINDOWS-1252"));
@@ -66,7 +76,7 @@ fn parse_intel_metadata() {
     assert!(matches!(vtc, readstat::ReadStatVarTypeClass::Numeric));
     assert!(matches!(vt, readstat::ReadStatVarType::Double));
     assert!(vfc.is_none());
-    assert_eq!(vf, String::from(""));
+    assert_eq!(vf, String::new());
     assert!(matches!(adt, DataType::Float64));
 
     // 1 - VOCABULARY
@@ -74,7 +84,7 @@ fn parse_intel_metadata() {
     assert!(matches!(vtc, readstat::ReadStatVarTypeClass::Numeric));
     assert!(matches!(vt, readstat::ReadStatVarType::Double));
     assert!(vfc.is_none());
-    assert_eq!(vf, String::from(""));
+    assert_eq!(vf, String::new());
     assert!(matches!(adt, DataType::Float64));
 
     // 2 - INFERENCE
@@ -82,7 +92,7 @@ fn parse_intel_metadata() {
     assert!(matches!(vtc, readstat::ReadStatVarTypeClass::Numeric));
     assert!(matches!(vt, readstat::ReadStatVarType::Double));
     assert!(vfc.is_none());
-    assert_eq!(vf, String::from(""));
+    assert_eq!(vf, String::new());
     assert!(matches!(adt, DataType::Float64));
 
     // 3 - REASONING
@@ -90,7 +100,7 @@ fn parse_intel_metadata() {
     assert!(matches!(vtc, readstat::ReadStatVarTypeClass::Numeric));
     assert!(matches!(vt, readstat::ReadStatVarType::Double));
     assert!(vfc.is_none());
-    assert_eq!(vf, String::from(""));
+    assert_eq!(vf, String::new());
     assert!(matches!(adt, DataType::Float64));
 
     // 4 - WRITING
@@ -98,7 +108,7 @@ fn parse_intel_metadata() {
     assert!(matches!(vtc, readstat::ReadStatVarTypeClass::Numeric));
     assert!(matches!(vt, readstat::ReadStatVarType::Double));
     assert!(vfc.is_none());
-    assert_eq!(vf, String::from(""));
+    assert_eq!(vf, String::new());
     assert!(matches!(adt, DataType::Float64));
 
     // 5 - GRAMMAR
@@ -106,7 +116,7 @@ fn parse_intel_metadata() {
     assert!(matches!(vtc, readstat::ReadStatVarTypeClass::Numeric));
     assert!(matches!(vt, readstat::ReadStatVarType::Double));
     assert!(vfc.is_none());
-    assert_eq!(vf, String::from(""));
+    assert_eq!(vf, String::new());
     assert!(matches!(adt, DataType::Float64));
 }
 

--- a/crates/readstat-tests/tests/parse_largepage_err_test.rs
+++ b/crates/readstat-tests/tests/parse_largepage_err_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use readstat::{ReadStatData, ReadStatMetadata, ReadStatPath};
 
 mod common;
@@ -38,7 +48,7 @@ fn parse_largepage_err() {
     assert_eq!(md.table_name, String::from("RAND_DS_LARGEPAGE_ERR"));
 
     // table label
-    assert_eq!(md.file_label, String::from(""));
+    assert_eq!(md.file_label, String::new());
 
     // file encoding
     assert_eq!(md.file_encoding, String::from("UTF-8"));

--- a/crates/readstat-tests/tests/parse_largepage_ok_test.rs
+++ b/crates/readstat-tests/tests/parse_largepage_ok_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use readstat::{ReadStatData, ReadStatMetadata, ReadStatPath};
 
 mod common;
@@ -38,7 +48,7 @@ fn parse_largepage_ok() {
     assert_eq!(md.table_name, String::from("RAND_DS_LARGEPAGE_OK"));
 
     // table label
-    assert_eq!(md.file_label, String::from(""));
+    assert_eq!(md.file_label, String::new());
 
     // file encoding
     assert_eq!(md.file_encoding, String::from("UTF-8"));

--- a/crates/readstat-tests/tests/parse_malformed_utf8_test.rs
+++ b/crates/readstat-tests/tests/parse_malformed_utf8_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::DataType;
 use common::ExpectedMetadata;
 

--- a/crates/readstat-tests/tests/parse_messydata_test.rs
+++ b/crates/readstat-tests/tests/parse_messydata_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::DataType;
 use arrow_array::{Float64Array, StringArray};
 use readstat::{ReadStatData, ReadStatMetadata, ReadStatPath};
@@ -31,7 +41,7 @@ fn parse_messydata_metadata() {
     assert_eq!(md.table_name, String::from("MESSYDATA"));
 
     // table label
-    assert_eq!(md.file_label, String::from(""));
+    assert_eq!(md.file_label, String::new());
 
     // file encoding
     assert_eq!(md.file_encoding, String::from("WINDOWS-1252"));

--- a/crates/readstat-tests/tests/parse_scientific_notation_test.rs
+++ b/crates/readstat-tests/tests/parse_scientific_notation_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::DataType;
 use arrow_array::Float64Array;
 use readstat::{ReadStatData, ReadStatMetadata, ReadStatPath};
@@ -102,7 +112,7 @@ fn parse_scientific_notation_metadata() {
     assert_eq!(md.table_name, String::from("SCIENTIFIC_NOTATION"));
 
     // table label
-    assert_eq!(md.file_label, String::from(""));
+    assert_eq!(md.file_label, String::new());
 
     // file encoding
     assert_eq!(md.file_encoding, String::from("UTF-8"));

--- a/crates/readstat-tests/tests/parse_somedata_test.rs
+++ b/crates/readstat-tests/tests/parse_somedata_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::DataType;
 use common::ExpectedMetadata;
 

--- a/crates/readstat-tests/tests/parse_somemiss_test.rs
+++ b/crates/readstat-tests/tests/parse_somemiss_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::DataType;
 use arrow_array::{Array, Float64Array, StringArray};
 use readstat::{ReadStatData, ReadStatMetadata, ReadStatPath};
@@ -31,7 +41,7 @@ fn parse_somemiss_metadata() {
     assert_eq!(md.table_name, String::from("SOMEMISS"));
 
     // table label
-    assert_eq!(md.file_label, String::from(""));
+    assert_eq!(md.file_label, String::new());
 
     // file encoding
     assert_eq!(md.file_encoding, String::from("WINDOWS-1252"));

--- a/crates/readstat-tests/tests/row_offset_test.rs
+++ b/crates/readstat-tests/tests/row_offset_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::{DataType, TimeUnit};
 use arrow_array::Array;
 use chrono::NaiveDate;

--- a/crates/readstat-tests/tests/skip_row_count_test.rs
+++ b/crates/readstat-tests/tests/skip_row_count_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 use arrow::datatypes::{DataType, TimeUnit};
 use arrow_array::Array;
 use chrono::{NaiveDate, TimeZone, Utc};

--- a/crates/readstat-tests/tests/sql_query_test.rs
+++ b/crates/readstat-tests/tests/sql_query_test.rs
@@ -1,3 +1,13 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 #![cfg(feature = "sql")]
 
 use arrow_array::{Array, Float64Array};

--- a/crates/readstat-tests/tests/string_alloc_bench.rs
+++ b/crates/readstat-tests/tests/string_alloc_bench.rs
@@ -1,7 +1,17 @@
+#![allow(clippy::float_cmp)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::cast_precision_loss)]
+#![allow(clippy::cast_lossless)]
+
 //! Benchmark the full data reading pipeline (FFI parse + Arrow conversion).
 //!
 //! Run with:
-//!   cargo test -p readstat-tests --release string_alloc_bench -- --nocapture --ignored
+//!   cargo test -p readstat-tests --release `string_alloc_bench` -- --nocapture --ignored
 
 mod common;
 
@@ -12,7 +22,7 @@ use std::time::Instant;
 /// Requires the AHS dataset to be downloaded first:
 ///   ./crates/readstat-tests/util/download_ahs.sh
 #[test]
-#[ignore] // Large file — run explicitly
+#[ignore = "benchmark, not a regular test"]
 fn bench_ahs_string_allocation() {
     let dataset = "_ahs2019n.sas7bdat";
 

--- a/crates/readstat/benches/readstat_benchmarks.rs
+++ b/crates/readstat/benches/readstat_benchmarks.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::cast_sign_loss, clippy::cast_lossless)]
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use readstat::{ReadStatData, ReadStatMetadata, ReadStatPath, ReadStatWriter, WriteConfig};
 use std::path::PathBuf;
@@ -25,7 +26,7 @@ fn setup_write_config(
     temp_dir: &TempDir,
     format: readstat::OutFormat,
 ) -> WriteConfig {
-    let output_path = temp_dir.path().join(format!("output.{:?}", format));
+    let output_path = temp_dir.path().join(format!("output.{format:?}"));
     WriteConfig::new(Some(output_path), Some(format), true, None, None).unwrap()
 }
 
@@ -111,7 +112,7 @@ fn bench_read_data_chunked(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmark: Arrow RecordBatch conversion
+/// Benchmark: Arrow `RecordBatch` conversion
 fn bench_arrow_conversion(c: &mut Criterion) {
     let mut group = c.benchmark_group("arrow_conversion");
 
@@ -226,7 +227,7 @@ fn bench_write_parquet_compression(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmark: Parallel write with SpooledTempFile (different buffer sizes)
+/// Benchmark: Parallel write with `SpooledTempFile` (different buffer sizes)
 fn bench_parallel_write_buffer_sizes(c: &mut Criterion) {
     let mut group = c.benchmark_group("parallel_write_buffer_sizes");
 
@@ -252,7 +253,7 @@ fn bench_parallel_write_buffer_sizes(c: &mut Criterion) {
                 b.iter(|| {
                     let output_path = temp_dir
                         .path()
-                        .join(format!("output_buf_{}.parquet", buffer_mb));
+                        .join(format!("output_buf_{buffer_mb}.parquet"));
                     let buffer_bytes = buffer_mb * 1024 * 1024;
 
                     if let Some(batch) = &d.batch {

--- a/crates/readstat/src/common.rs
+++ b/crates/readstat/src/common.rs
@@ -158,7 +158,7 @@ mod tests {
         // Build one explicitly so the test is self-contained.
         let mut buf = b"caf\xC3".to_vec();
         buf.push(0); // null terminator
-        let ptr = buf.as_ptr() as *const i8;
+        let ptr = buf.as_ptr().cast::<i8>();
 
         let result = ptr_to_string(ptr);
         assert_eq!(result, "caf\u{FFFD}");
@@ -169,7 +169,7 @@ mod tests {
         // 0xFF is never valid in UTF-8
         let mut buf = b"hello\xFFworld".to_vec();
         buf.push(0);
-        let ptr = buf.as_ptr() as *const i8;
+        let ptr = buf.as_ptr().cast::<i8>();
 
         let result = ptr_to_string(ptr);
         assert_eq!(result, "hello\u{FFFD}world");

--- a/crates/readstat/src/formats.rs
+++ b/crates/readstat/src/formats.rs
@@ -259,8 +259,7 @@ mod tests {
             assert_eq!(
                 match_var_format(fmt),
                 Some(ReadStatVarFormatClass::Date),
-                "Expected Date for format: {}",
-                fmt
+                "Expected Date for format: {fmt}"
             );
         }
     }
@@ -302,8 +301,7 @@ mod tests {
             assert_eq!(
                 match_var_format(fmt),
                 Some(ReadStatVarFormatClass::Time),
-                "Expected Time for format: {}",
-                fmt
+                "Expected Time for format: {fmt}"
             );
         }
     }
@@ -400,8 +398,7 @@ mod tests {
             assert_eq!(
                 match_var_format(fmt),
                 Some(ReadStatVarFormatClass::DateTime),
-                "Expected DateTime for format: {}",
-                fmt
+                "Expected DateTime for format: {fmt}"
             );
         }
     }

--- a/crates/readstat/src/rs_metadata.rs
+++ b/crates/readstat/src/rs_metadata.rs
@@ -454,6 +454,7 @@ mod tests {
     use std::io::Write;
 
     /// Create a test metadata instance with the given variable names.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     fn test_metadata(var_names: &[&str]) -> ReadStatMetadata {
         let mut md = ReadStatMetadata::new();
         for (i, name) in var_names.iter().enumerate() {


### PR DESCRIPTION
Zero warnings now with `cargo clippy --workspace --all-targets -- -W clippy::all -W clippy::pedantic`.

Library crate: fixed ptr_as_ptr and uninlined_format_args lints. Sys crates: suppressed bindgen-generated lint noise (missing_safety_doc, useless_transmute, ptr_offset_with_cast).
Test crate: added #![allow] blocks for test-acceptable patterns, fixed String::from("") -> String::new(), needless raw string hashes, redundant closures, and doc_markdown warnings.
Benchmarks: fixed format args, doc_markdown, and allowed cast lints. Changelog: added missing date for 0.18.0.