### PR TITLE
Fix clippy warnings and harden release-check scripts

### DIFF
--- a/crates/readstat-tests/tests/sql_query_test.rs
+++ b/crates/readstat-tests/tests/sql_query_test.rs
@@ -310,15 +310,21 @@ fn sql_stream_and_write() {
     let temp_dir = std::env::temp_dir();
     let out_path = temp_dir.join("sql_stream_test_output.parquet");
 
+    let write_config = readstat::WriteConfig::new(
+        Some(out_path.clone()),
+        Some(readstat::OutFormat::Parquet),
+        true,
+        None,
+        None,
+    )
+    .unwrap();
+
     readstat::execute_sql_and_write_stream(
         receiver,
         schema,
         "cars",
         "SELECT \"Brand\", \"Model\", \"EngineSize\" FROM cars WHERE \"EngineSize\" > 5.0",
-        &out_path,
-        readstat::OutFormat::Parquet,
-        None,
-        None,
+        &write_config,
     )
     .unwrap();
 

--- a/crates/readstat/src/rs_query.rs
+++ b/crates/readstat/src/rs_query.rs
@@ -24,7 +24,13 @@ use std::sync::{Arc, Mutex};
 use crate::err::ReadStatError;
 use crate::rs_data::ReadStatData;
 use crate::rs_path::ReadStatPath;
-use crate::rs_write_config::{OutFormat, ParquetCompression, resolve_parquet_compression};
+use crate::rs_write_config::{OutFormat, ParquetCompression, WriteConfig, resolve_parquet_compression};
+
+/// Channel receiver type for streaming parsed data chunks between threads.
+///
+/// Each message contains the parsed [`ReadStatData`], the source [`ReadStatPath`],
+/// and the chunk index.
+type ChunkReceiver = crossbeam::channel::Receiver<(ReadStatData, ReadStatPath, usize)>;
 
 /// Executes a SQL query against in-memory Arrow data.
 ///
@@ -71,13 +77,13 @@ async fn execute_sql_async(
 #[derive(Debug)]
 struct ChannelPartitionStream {
     schema: SchemaRef,
-    receiver: Arc<Mutex<Option<crossbeam::channel::Receiver<(ReadStatData, ReadStatPath, usize)>>>>,
+    receiver: Arc<Mutex<Option<ChunkReceiver>>>,
 }
 
 impl ChannelPartitionStream {
     fn new(
         schema: SchemaRef,
-        receiver: crossbeam::channel::Receiver<(ReadStatData, ReadStatPath, usize)>,
+        receiver: ChunkReceiver,
     ) -> Self {
         Self {
             schema,
@@ -112,7 +118,7 @@ impl PartitionStream for ChannelPartitionStream {
 /// The receiver is consumed directly by DataFusion's query engine via
 /// [`StreamingTable`], and results are collected via `execute_stream()`.
 pub fn execute_sql_stream(
-    receiver: crossbeam::channel::Receiver<(ReadStatData, ReadStatPath, usize)>,
+    receiver: ChunkReceiver,
     schema: SchemaRef,
     table_name: &str,
     sql: &str,
@@ -122,7 +128,7 @@ pub fn execute_sql_stream(
 }
 
 async fn execute_sql_stream_async(
-    receiver: crossbeam::channel::Receiver<(ReadStatData, ReadStatPath, usize)>,
+    receiver: ChunkReceiver,
     schema: SchemaRef,
     table_name: &str,
     sql: &str,
@@ -149,15 +155,14 @@ async fn execute_sql_stream_async(
 ///
 /// This combines [`execute_sql_stream`] and [`write_sql_results`] into one
 /// streaming pass for the Data command path.
+///
+/// The output path in `write_config` must be `Some`; returns an error otherwise.
 pub fn execute_sql_and_write_stream(
-    receiver: crossbeam::channel::Receiver<(ReadStatData, ReadStatPath, usize)>,
+    receiver: ChunkReceiver,
     schema: SchemaRef,
     table_name: &str,
     sql: &str,
-    output_path: &Path,
-    format: OutFormat,
-    compression: Option<ParquetCompression>,
-    compression_level: Option<u32>,
+    write_config: &WriteConfig,
 ) -> Result<(), ReadStatError> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(execute_sql_and_write_stream_async(
@@ -165,23 +170,22 @@ pub fn execute_sql_and_write_stream(
         schema,
         table_name,
         sql,
-        output_path,
-        format,
-        compression,
-        compression_level,
+        write_config,
     ))
 }
 
 async fn execute_sql_and_write_stream_async(
-    receiver: crossbeam::channel::Receiver<(ReadStatData, ReadStatPath, usize)>,
+    receiver: ChunkReceiver,
     schema: SchemaRef,
     table_name: &str,
     sql: &str,
-    output_path: &Path,
-    format: OutFormat,
-    compression: Option<ParquetCompression>,
-    compression_level: Option<u32>,
+    write_config: &WriteConfig,
 ) -> Result<(), ReadStatError> {
+    let output_path = write_config
+        .out_path
+        .as_deref()
+        .ok_or_else(|| ReadStatError::Other("Output path is required for SQL write".into()))?;
+
     let ctx = SessionContext::new();
 
     let partition = ChannelPartitionStream::new(schema.clone(), receiver);
@@ -202,9 +206,9 @@ async fn execute_sql_and_write_stream_async(
     write_sql_results(
         &result_batches,
         output_path,
-        format,
-        compression,
-        compression_level,
+        write_config.format,
+        write_config.compression,
+        write_config.compression_level,
     )?;
 
     Ok(())

--- a/scripts/release-check.ps1
+++ b/scripts/release-check.ps1
@@ -43,11 +43,11 @@ if ($LASTEXITCODE -eq 0) {
 
 # 2. Clippy
 Write-Host "Checking clippy..."
-$clippyOutput = cargo clippy --workspace 2>&1
-if ($clippyOutput -match "warning:") {
-    Write-Fail "cargo clippy — warnings found"
-} else {
+cargo clippy --workspace --all-targets -- -D warnings *>$null
+if ($LASTEXITCODE -eq 0) {
     Write-Pass "cargo clippy"
+} else {
+    Write-Fail "cargo clippy — warnings or errors found"
 }
 
 # 2b. readstat-wasm (excluded from workspace - check separately)
@@ -61,11 +61,11 @@ if (Test-Path $WasmDir) {
     } else {
         Write-Fail "readstat-wasm fmt — run 'cargo fmt' in crates\readstat-wasm\"
     }
-    $wasmClippyOutput = cargo clippy 2>&1
-    if ($wasmClippyOutput -match "warning:") {
-        Write-Fail "readstat-wasm clippy — warnings found"
-    } else {
+    cargo clippy -- -D warnings *>$null
+    if ($LASTEXITCODE -eq 0) {
         Write-Pass "readstat-wasm clippy"
+    } else {
+        Write-Fail "readstat-wasm clippy — warnings or errors found"
     }
     Pop-Location
 } else {
@@ -74,8 +74,8 @@ if (Test-Path $WasmDir) {
 
 # 3. Tests
 Write-Host "Running tests..."
-$testOutput = cargo test --workspace 2>&1
-if ($testOutput -match "test result: ok") {
+cargo test --workspace *>$null
+if ($LASTEXITCODE -eq 0) {
     Write-Pass "cargo test"
 } else {
     Write-Fail "cargo test — some tests failed"
@@ -83,8 +83,12 @@ if ($testOutput -match "test result: ok") {
 
 # 4. Doc build
 Write-Host "Checking doc build..."
-$docOutput = cargo doc --workspace --no-deps 2>&1
-Write-Pass "cargo doc"
+cargo doc --workspace --no-deps *>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Pass "cargo doc"
+} else {
+    Write-Fail "cargo doc — build failed"
+}
 
 # 5. cargo-deny (optional)
 Write-Host "Checking dependencies..."

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -48,10 +48,10 @@ fi
 
 # 2. Clippy
 echo "Checking clippy..."
-if cargo clippy --workspace 2>&1 | grep -q "warning:"; then
-    fail "cargo clippy — warnings found"
-else
+if cargo clippy --workspace --all-targets -- -D warnings &>/dev/null; then
     pass "cargo clippy"
+else
+    fail "cargo clippy — warnings or errors found"
 fi
 
 # 2b. readstat-wasm (excluded from workspace — check separately)
@@ -63,10 +63,10 @@ if [ -d "$WASM_DIR" ]; then
     else
         fail "readstat-wasm fmt — run 'cargo fmt' in crates/readstat-wasm/"
     fi
-    if (cd "$WASM_DIR" && cargo clippy) 2>&1 | grep -q "warning:"; then
-        fail "readstat-wasm clippy — warnings found"
-    else
+    if (cd "$WASM_DIR" && cargo clippy -- -D warnings) &>/dev/null; then
         pass "readstat-wasm clippy"
+    else
+        fail "readstat-wasm clippy — warnings or errors found"
     fi
 else
     warn "readstat-wasm directory not found — skipping"
@@ -74,7 +74,7 @@ fi
 
 # 3. Tests
 echo "Running tests..."
-if cargo test --workspace 2>&1 | grep -q "test result: ok"; then
+if cargo test --workspace &>/dev/null; then
     pass "cargo test"
 else
     fail "cargo test — some tests failed"
@@ -82,11 +82,10 @@ fi
 
 # 4. Doc build
 echo "Checking doc build..."
-if cargo doc --workspace --no-deps 2>&1 | grep -qv "warning:.*output filename collision"; then
-    # Filter out the known name collision warning
+if cargo doc --workspace --no-deps &>/dev/null; then
     pass "cargo doc"
 else
-    pass "cargo doc"
+    fail "cargo doc — build failed"
 fi
 
 # 5. cargo-deny (optional)


### PR DESCRIPTION
- Fix 3 clippy warnings in rs_query.rs (sql feature):
  - Add ChunkReceiver type alias to resolve type_complexity warning
  - Refactor execute_sql_and_write_stream to accept &WriteConfig, reducing arg count from 8 to 5 (too_many_arguments)
- Fix fragile checks in release-check.sh and release-check.ps1:
  - Clippy: use exit code with -D warnings instead of grepping output
  - Tests: use cargo test exit code instead of grepping "test result: ok"
  - Docs: actually check exit code instead of always passing

https://claude.ai/code/session_017TYV6myroMBGLAJMBvWVKn