### PR TITLE
Bump to 0.20.2, apply cargo fmt, improve expect messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.20.2] - 2026-03-04
+
+### Changed
+- Bumped `readstat` and `readstat-cli` to 0.20.2 for crates.io release
+- Applied `cargo fmt` to fix formatting drift in `cb.rs`, `rs_data.rs`, and `rs_query.rs`
+- Replaced `CString::new("").unwrap()` with `expect("empty string is valid C string")` in buffer I/O dummy paths for clearer intent
+
 ## [0.20.0] - 2026-03-03
 
 ### Changed

--- a/crates/readstat-cli/Cargo.toml
+++ b/crates/readstat-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readstat-cli"
-version = "0.20.0"
+version = "0.20.2"
 authors = ["Curtis Alexander <calex@calex.org>"]
 edition = "2024"
 rust-version = "1.85"
@@ -18,7 +18,7 @@ name = "readstat"
 path = "src/main.rs"
 
 [dependencies]
-readstat = { path = "../readstat", version = "0.20.0" }
+readstat = { path = "../readstat", version = "0.20.2" }
 
 arrow-array = { workspace = true }
 arrow-csv = { workspace = true, optional = true }

--- a/crates/readstat/Cargo.toml
+++ b/crates/readstat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readstat"
-version = "0.20.0"
+version = "0.20.2"
 authors = ["Curtis Alexander <calex@calex.org>"]
 edition = "2024"
 rust-version = "1.85"

--- a/crates/readstat/src/cb.rs
+++ b/crates/readstat/src/cb.rs
@@ -83,16 +83,14 @@ pub(crate) extern "C" fn handle_metadata(
     .to_string();
 
     #[allow(clippy::useless_conversion)]
-    let compression = FromPrimitive::from_i32(
-        unsafe { readstat_sys::readstat_get_compression(metadata) } as i32,
-    )
-    .unwrap_or(ReadStatCompress::None);
+    let compression =
+        FromPrimitive::from_i32(unsafe { readstat_sys::readstat_get_compression(metadata) } as i32)
+            .unwrap_or(ReadStatCompress::None);
 
     #[allow(clippy::useless_conversion)]
-    let endianness = FromPrimitive::from_i32(
-        unsafe { readstat_sys::readstat_get_endianness(metadata) } as i32,
-    )
-    .unwrap_or(ReadStatEndian::None);
+    let endianness =
+        FromPrimitive::from_i32(unsafe { readstat_sys::readstat_get_endianness(metadata) } as i32)
+            .unwrap_or(ReadStatEndian::None);
 
     debug!("row_count is {rc}");
     debug!("var_count is {vc}");
@@ -151,16 +149,18 @@ pub(crate) extern "C" fn handle_variable(
 
     // get variable metadata
     #[allow(clippy::useless_conversion)]
-    let var_type = FromPrimitive::from_i32(
-        unsafe { readstat_sys::readstat_variable_get_type(variable) } as i32,
-    )
-    .unwrap_or(ReadStatVarType::Unknown);
+    let var_type =
+        FromPrimitive::from_i32(
+            unsafe { readstat_sys::readstat_variable_get_type(variable) } as i32,
+        )
+        .unwrap_or(ReadStatVarType::Unknown);
 
     #[allow(clippy::useless_conversion)]
-    let var_type_class = FromPrimitive::from_i32(
-        unsafe { readstat_sys::readstat_variable_get_type_class(variable) } as i32,
-    )
-    .unwrap_or(ReadStatVarTypeClass::Numeric);
+    let var_type_class =
+        FromPrimitive::from_i32(
+            unsafe { readstat_sys::readstat_variable_get_type_class(variable) } as i32,
+        )
+        .unwrap_or(ReadStatVarTypeClass::Numeric);
 
     let var_name = unsafe { ptr_to_string(readstat_sys::readstat_variable_get_name(variable)) };
     let var_label = unsafe { ptr_to_string(readstat_sys::readstat_variable_get_label(variable)) };

--- a/crates/readstat/src/rs_data.rs
+++ b/crates/readstat/src/rs_data.rs
@@ -129,31 +129,29 @@ impl ColumnBuilder {
                     Some(ReadStatVarFormatClass::Date) => {
                         Self::Date32(Date32Builder::with_capacity(capacity))
                     }
-                    Some(ReadStatVarFormatClass::DateTime) => Self::TimestampSecond(
-                        TimestampSecondBuilder::with_capacity(capacity),
-                    ),
+                    Some(ReadStatVarFormatClass::DateTime) => {
+                        Self::TimestampSecond(TimestampSecondBuilder::with_capacity(capacity))
+                    }
                     Some(ReadStatVarFormatClass::DateTimeWithMilliseconds) => {
-                        Self::TimestampMillisecond(
-                            TimestampMillisecondBuilder::with_capacity(capacity),
-                        )
+                        Self::TimestampMillisecond(TimestampMillisecondBuilder::with_capacity(
+                            capacity,
+                        ))
                     }
                     Some(ReadStatVarFormatClass::DateTimeWithMicroseconds) => {
-                        Self::TimestampMicrosecond(
-                            TimestampMicrosecondBuilder::with_capacity(capacity),
-                        )
+                        Self::TimestampMicrosecond(TimestampMicrosecondBuilder::with_capacity(
+                            capacity,
+                        ))
                     }
                     Some(ReadStatVarFormatClass::DateTimeWithNanoseconds) => {
-                        Self::TimestampNanosecond(
-                            TimestampNanosecondBuilder::with_capacity(capacity),
-                        )
+                        Self::TimestampNanosecond(TimestampNanosecondBuilder::with_capacity(
+                            capacity,
+                        ))
                     }
                     Some(ReadStatVarFormatClass::Time) => {
                         Self::Time32Second(Time32SecondBuilder::with_capacity(capacity))
                     }
                     Some(ReadStatVarFormatClass::TimeWithMicroseconds) => {
-                        Self::Time64Microsecond(Time64MicrosecondBuilder::with_capacity(
-                            capacity,
-                        ))
+                        Self::Time64Microsecond(Time64MicrosecondBuilder::with_capacity(capacity))
                     }
                     None => {
                         // Plain numeric — dispatch by storage type
@@ -381,7 +379,7 @@ impl ReadStatData {
         debug!("Initially, error ==> {error:#?}");
 
         // Dummy path — custom I/O handlers ignore it
-        let dummy_path = CString::new("").unwrap();
+        let dummy_path = CString::new("").expect("empty string is valid C string");
 
         // setup parser with buffer I/O
         let error = buffer_ctx

--- a/crates/readstat/src/rs_metadata.rs
+++ b/crates/readstat/src/rs_metadata.rs
@@ -219,7 +219,7 @@ impl ReadStatMetadata {
         let row_limit = if skip_row_count { Some(1) } else { None };
 
         // Dummy path — custom I/O handlers ignore it
-        let dummy_path = CString::new("").unwrap();
+        let dummy_path = CString::new("").expect("empty string is valid C string");
 
         let error = buffer_ctx
             .configure_parser(

--- a/crates/readstat/src/rs_query.rs
+++ b/crates/readstat/src/rs_query.rs
@@ -24,7 +24,9 @@ use std::sync::{Arc, Mutex};
 use crate::err::ReadStatError;
 use crate::rs_data::ReadStatData;
 use crate::rs_path::ReadStatPath;
-use crate::rs_write_config::{OutFormat, ParquetCompression, WriteConfig, resolve_parquet_compression};
+use crate::rs_write_config::{
+    OutFormat, ParquetCompression, WriteConfig, resolve_parquet_compression,
+};
 
 /// Channel receiver type for streaming parsed data chunks between threads.
 ///
@@ -81,10 +83,7 @@ struct ChannelPartitionStream {
 }
 
 impl ChannelPartitionStream {
-    fn new(
-        schema: SchemaRef,
-        receiver: ChunkReceiver,
-    ) -> Self {
+    fn new(schema: SchemaRef, receiver: ChunkReceiver) -> Self {
         Self {
             schema,
             receiver: Arc::new(Mutex::new(Some(receiver))),


### PR DESCRIPTION
- Bump readstat and readstat-cli versions from 0.20.0 to 0.20.2
- Apply cargo fmt to fix formatting drift in cb.rs, rs_data.rs, rs_query.rs
- Replace CString::new("").unwrap() with expect() for clearer intent
- Update CHANGELOG with 0.20.2 entry

https://claude.ai/code/session_01U9nCqzgnnk9FNG1ANy2Dhy