### PR TITLE
Clarify SAS-only support in readstat and readstat-cli READMEs

### DIFF
--- a/crates/readstat-cli/README.md
+++ b/crates/readstat-cli/README.md
@@ -1,6 +1,8 @@
 # readstat-cli
 
-Binary crate producing the `readstat` CLI tool for converting SAS binary files (`.sas7bdat`) to other formats. Currently supports **SAS `.sas7bdat` files only** (SPSS and Stata formats are not implemented).
+Binary crate producing the `readstat` CLI tool for converting SAS binary files (`.sas7bdat`) to other formats.
+
+> **Note:** The ReadStat C library supports SAS, SPSS, and Stata file formats. The [`readstat-sys`](https://crates.io/crates/readstat-sys) crate exposes the **full** ReadStat API &mdash; all 125 functions across all formats. However, this CLI currently only supports **SAS `.sas7bdat` files**. SPSS and Stata formats are not supported.
 
 ## Subcommands
 

--- a/crates/readstat-sys/README.md
+++ b/crates/readstat-sys/README.md
@@ -4,9 +4,9 @@ Raw FFI bindings to the [ReadStat](https://github.com/WizardMac/ReadStat) C libr
 
 The `build.rs` script compiles ~49 C source files from the vendored `vendor/ReadStat/` git submodule via the `cc` crate and generates Rust bindings with `bindgen`. Platform-specific linking for iconv and zlib is handled automatically (see [docs/BUILDING.md](https://github.com/curtisalexander/readstat-rs/blob/main/docs/BUILDING.md) for details).
 
-These bindings expose the **full** ReadStat API, including support for SAS (`.sas7bdat`, `.xpt`), SPSS (`.sav`, `.zsav`, `.por`), and Stata (`.dta`) file formats.
+These bindings expose the **full** ReadStat API &mdash; all 125 functions and all 8 enum types &mdash; including support for **SAS** (`.sas7bdat`, `.xpt`), **SPSS** (`.sav`, `.zsav`, `.por`), and **Stata** (`.dta`) file formats. If you need to work with SPSS or Stata files from Rust, this crate provides the complete FFI surface to do so.
 
-This is a [sys crate](https://kornel.ski/rust-sys-crate) — it exposes raw C types and functions. Use the [`readstat`](https://crates.io/crates/readstat) library crate for a safe, high-level API (currently SAS `.sas7bdat` only).
+This is a [sys crate](https://kornel.ski/rust-sys-crate) — it exposes raw C types and functions. The higher-level [`readstat`](https://crates.io/crates/readstat) library crate provides a safe API but currently only implements support for SAS `.sas7bdat` files.
 
 ## API Coverage
 

--- a/crates/readstat/README.md
+++ b/crates/readstat/README.md
@@ -2,7 +2,7 @@
 
 Pure Rust library for parsing SAS binary files (`.sas7bdat`) into Apache Arrow RecordBatch format. Uses FFI bindings to the [ReadStat](https://github.com/WizardMac/ReadStat) C library for parsing.
 
-**Note:** While the underlying [`readstat-sys`](https://crates.io/crates/readstat-sys) crate exposes bindings for all formats supported by ReadStat (SAS, SPSS, Stata), this crate currently only implements parsing and conversion for **SAS `.sas7bdat` files**.
+> **Note:** The ReadStat C library supports SAS, SPSS, and Stata file formats. The [`readstat-sys`](https://crates.io/crates/readstat-sys) crate exposes the **full** ReadStat API &mdash; all 125 functions across all formats. However, this crate currently only implements parsing and conversion for **SAS `.sas7bdat` files**. SPSS and Stata formats are not supported.
 
 ## Features
 


### PR DESCRIPTION
Use consistent blockquote callout style (matching root README) across all three crate READMEs to make format support crystal clear for crates.io consumers:

- readstat: SAS .sas7bdat only, prominent callout
- readstat-cli: SAS .sas7bdat only, prominent callout
- readstat-sys: emphasize full API coverage for all formats (SAS, SPSS, Stata) and invite consumers who need other formats

https://claude.ai/code/session_01KuVDgRmcmMQCbN6cFn2mHm