### PR TITLE
Fix fuzz OOM crash and upgrade GitHub Actions

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,7 +18,7 @@ jobs:
           - fuzz_read_data
           - fuzz_read_data_filtered
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -32,21 +32,21 @@ jobs:
 
       - name: Upload corpus
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: corpus-${{ matrix.target }}
           path: fuzz/corpus/${{ matrix.target }}/
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: crashes-${{ matrix.target }}
           path: fuzz/artifacts/${{ matrix.target }}/
 
       - name: Open issue on crash
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const target = '${{ matrix.target }}';

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Generate changelog
@@ -102,7 +102,7 @@ jobs:
             echo "VERSION=${{ github.event.client_payload.version || 'dev' }}" >> $GITHUB_OUTPUT
           fi
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install toolchain
@@ -118,7 +118,7 @@ jobs:
       - name: Zip
         run: tar czvf target/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz --directory=target/release ${{ env.PACKAGE_NAME }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}
           path: target/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
@@ -146,7 +146,7 @@ jobs:
             echo "VERSION=${{ github.event.client_payload.version || 'dev' }}" >> $GITHUB_OUTPUT
           fi
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install toolchain
@@ -162,7 +162,7 @@ jobs:
       - name: Zip
         run: tar czvf target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz --directory=target/${{ env.target }}/release ${{ env.PACKAGE_NAME }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}
           path: target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
@@ -191,7 +191,7 @@ jobs:
           fi
         shell: bash
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install toolchain
@@ -202,7 +202,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Cache LLVM and Clang
         id: cache-llvm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}\llvm
           key: llvm-21.1.8
@@ -220,7 +220,7 @@ jobs:
       - name: Zip
         run: Compress-Archive -Path target\release\${{ env.PACKAGE_NAME }}.exe -DestinationPath target\release\${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.zip  -CompressionLevel Optimal
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}
           path: target/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.zip
@@ -248,7 +248,7 @@ jobs:
             echo "VERSION=${{ github.event.client_payload.version || 'dev' }}" >> $GITHUB_OUTPUT
           fi
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install toolchain
@@ -262,7 +262,7 @@ jobs:
       - name: Zip
         run: tar czvf target/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz --directory=target/release ${{ env.PACKAGE_NAME }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}
           path: target/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
@@ -291,7 +291,7 @@ jobs:
             echo "VERSION=${{ github.event.client_payload.version || 'dev' }}" >> $GITHUB_OUTPUT
           fi
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install toolchain
@@ -305,7 +305,7 @@ jobs:
       - name: Zip
         run: tar czvf target/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz --directory=target/release ${{ env.PACKAGE_NAME }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}
           path: target/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
@@ -326,7 +326,7 @@ jobs:
       MIRIFLAGS: "-Zmiri-disable-isolation"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install nightly toolchain with Miri
@@ -345,7 +345,7 @@ jobs:
       READSTAT_SANITIZE_ADDRESS: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install nightly toolchain
@@ -363,7 +363,7 @@ jobs:
       RUSTFLAGS: "-Zsanitizer=address"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install nightly toolchain
@@ -381,7 +381,7 @@ jobs:
       RUSTFLAGS: "-Zsanitizer=address"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install nightly toolchain
@@ -394,7 +394,7 @@ jobs:
       # The ASAN runtime comes from Visual Studio (MSVC), not from this LLVM install.
       - name: Cache LLVM and Clang
         id: cache-llvm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}\llvm
           key: llvm-21.1.8
@@ -435,7 +435,7 @@ jobs:
       READSTAT_SANITIZE_ADDRESS: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install nightly toolchain
@@ -448,7 +448,7 @@ jobs:
       # The ASAN runtime comes from Visual Studio (MSVC), not from this LLVM install.
       - name: Cache LLVM and Clang
         id: cache-llvm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}\llvm
           key: llvm-21.1.8

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -37,7 +37,7 @@ jobs:
         run: bash scripts/build-book.sh --docs
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: target/book
 
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/fuzz/fuzz_targets/fuzz_read_data.rs
+++ b/fuzz/fuzz_targets/fuzz_read_data.rs
@@ -2,12 +2,17 @@
 use libfuzzer_sys::fuzz_target;
 use readstat::{ReadStatData, ReadStatMetadata};
 
+// Cap rows to avoid OOM from malformed metadata claiming billions of rows.
+// The library itself is fine — the CLI streams in 10k-row chunks — but the
+// fuzzer needs a hard ceiling so libFuzzer's default 2 GB RSS limit isn't hit.
+const MAX_ROWS: u32 = 100_000;
+
 fuzz_target!(|data: &[u8]| {
     let mut md = ReadStatMetadata::new();
     if md.read_metadata_from_bytes(data, false).is_err() {
         return;
     }
-    let row_count = md.row_count as u32;
+    let row_count = (md.row_count as u32).min(MAX_ROWS);
     let mut d = ReadStatData::new()
         .set_no_progress(true)
         .init(md, 0, row_count);

--- a/fuzz/fuzz_targets/fuzz_read_data_filtered.rs
+++ b/fuzz/fuzz_targets/fuzz_read_data_filtered.rs
@@ -14,6 +14,9 @@ struct FuzzInput<'a> {
     selected_columns: Vec<u16>,
 }
 
+// Cap rows to avoid OOM from malformed metadata claiming billions of rows.
+const MAX_ROWS: u32 = 100_000;
+
 fuzz_target!(|input: FuzzInput| {
     let mut md = ReadStatMetadata::new();
     if md.read_metadata_from_bytes(input.data, false).is_err() {
@@ -66,7 +69,7 @@ fuzz_target!(|input: FuzzInput| {
     md.var_count = selected.len() as i32;
     md.schema = Schema::new(filtered_fields);
 
-    let row_count = md.row_count as u32;
+    let row_count = (md.row_count as u32).min(MAX_ROWS);
     let mut d = ReadStatData::new()
         .set_no_progress(true)
         .set_column_filter(Some(Arc::new(filter)), total_var_count)


### PR DESCRIPTION
## Summary
- Cap `row_count` to 100k in `fuzz_read_data` and `fuzz_read_data_filtered` targets to prevent OOM when malformed metadata claims billions of rows (not a library bug — the CLI already streams in 10k-row chunks)
- Upgrade all GitHub Actions to Node.js 24-compatible versions: checkout v6, upload-artifact v7, cache v5, github-script v8, upload-pages-artifact v4, deploy-pages v5

Fixes #155

## Test plan
- [x] Crash file `crash-08ba0e306707f1a78647e13f87afcbf531a345ea` no longer triggers OOM
- [ ] Re-run fuzz workflow after merge to verify clean run

🤖 Generated with [Claude Code](https://claude.com/claude-code)