### PR TITLE
Document fuzz testing across project docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Clone the repository (with submodules), install platform-specific developer tool
 | [docs/USAGE.md](docs/USAGE.md) | Full CLI reference and examples |
 | [docs/BUILDING.md](docs/BUILDING.md) | Clone, build, and linking details per platform |
 | [docs/TECHNICAL.md](docs/TECHNICAL.md) | Floating-point precision and date/time handling |
-| [docs/TESTING.md](docs/TESTING.md) | Running tests, dataset table, valgrind |
+| [docs/TESTING.md](docs/TESTING.md) | Running tests, dataset table, fuzz testing, valgrind |
 | [docs/BENCHMARKING.md](docs/BENCHMARKING.md) | Criterion benchmarks, hyperfine, and profiling |
 | [docs/CI-CD.md](docs/CI-CD.md) | GitHub Actions triggers and artifacts |
 | [docs/MEMORY-SAFETY.md](docs/MEMORY-SAFETY.md) | Automated memory-safety CI checks (Valgrind, ASan, Miri, unsafe audit) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,6 +18,9 @@ readstat-rs/
 │   ├── readstat-iconv-sys/   # FFI bindings to iconv (Windows only)
 │   ├── readstat-tests/      # Integration test suite
 │   └── readstat-wasm/       # WebAssembly build (excluded from workspace)
+├── fuzz/                   # Fuzz testing (standalone Cargo project, cargo-fuzz)
+│   ├── fuzz_targets/        # 3 libFuzzer targets
+│   └── corpus/              # Seed corpus (14 .sas7bdat files per target)
 ├── examples/
 │   ├── cli-demo/            # CLI conversion demo
 │   ├── api-demo/            # REST API servers (Rust + Python)

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -90,6 +90,18 @@ Repository dispatch event types for API triggers:
 
 :memo: API triggers only build artifacts and do not create GitHub releases. To create a release, use a [tag push](#1-tag-push-release).
 
+## Fuzz Testing (`.github/workflows/fuzz.yml`)
+
+A separate workflow runs [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) (libFuzzer) targets against the `readstat` library's byte-parsing paths.
+
+- **Schedule**: Weekly, Monday 3am UTC
+- **Manual trigger**: `gh workflow run fuzz.yml` or via the Actions UI
+- **Duration**: 30 minutes per target (~90 min total)
+- **Targets**: `fuzz_read_metadata`, `fuzz_read_data`, `fuzz_read_data_filtered`
+- **On crash**: uploads crash artifacts and automatically opens a GitHub issue labeled `bug` + `fuzz`
+
+See [TESTING.md](TESTING.md#fuzz-testing) for local usage and target details.
+
 ## Artifacts
 
 All builds (regardless of trigger method) upload artifacts that can be downloaded from the workflow run page. Artifacts are retained for the default GitHub Actions retention period.

--- a/docs/MEMORY-SAFETY.md
+++ b/docs/MEMORY-SAFETY.md
@@ -132,3 +132,6 @@ valgrind ./target/debug/deps/parse_file_metadata_test-<hash>
 | ASan | macOS | Full workspace | No (runtime mismatch) | No |
 | ASan | Windows | Full workspace | Not yet (no mismatch — see [future work](#future-work-windows-c-instrumentation)) | No |
 | Valgrind | Linux (manual) | Full | Full | Yes |
+| cargo-fuzz | Linux (CI, weekly) | Full | Full | No |
+
+Fuzz testing exercises the FFI byte-parsing paths with arbitrary/malformed input via [libFuzzer](https://llvm.org/docs/LibFuzzer.html). See [TESTING.md](TESTING.md#fuzz-testing) for details.


### PR DESCRIPTION
## Summary
- Add `fuzz/` to ARCHITECTURE.md workspace layout
- Add fuzz workflow section to CI-CD.md (schedule, targets, crash behavior)
- Add cargo-fuzz row to MEMORY-SAFETY.md coverage summary table
- Update README.md docs table to mention fuzz testing
- Note `fuzz/` in CLAUDE.md conventions

## Test plan
- [x] All links/cross-references verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)