### PR TITLE
Fix fuzz crashes: bump Arrow to v58, add MAX_VARS cap

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
+checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
+checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
 dependencies = [
  "bytes",
  "half",
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
+checksum = "ca025bd0f38eeecb57c2153c0123b960494138e6a957bbda10da2b25415209fe"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
+checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
+checksum = "6ead0914e4861a531be48fe05858265cf854a4880b9ed12618b1d08cba9bebc8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
+checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -224,15 +224,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
 
 [[package]]
 name = "arrow-select"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.3.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
+checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -320,9 +320,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -735,9 +735,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "readstat"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1035,9 +1035,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,7 +16,7 @@ path = "../crates/readstat"
 default-features = false
 
 [dependencies.arrow]
-version = "57"
+version = "58"
 
 [workspace]
 members = ["."]

--- a/fuzz/fuzz_targets/fuzz_read_data.rs
+++ b/fuzz/fuzz_targets/fuzz_read_data.rs
@@ -2,14 +2,18 @@
 use libfuzzer_sys::fuzz_target;
 use readstat::{ReadStatData, ReadStatMetadata};
 
-// Cap rows to avoid OOM from malformed metadata claiming billions of rows.
+// Cap rows and columns to avoid OOM from malformed metadata.
 // The library itself is fine — the CLI streams in 10k-row chunks — but the
-// fuzzer needs a hard ceiling so libFuzzer's default 2 GB RSS limit isn't hit.
+// fuzzer needs hard ceilings so libFuzzer's default 2 GB RSS limit isn't hit.
 const MAX_ROWS: u32 = 100_000;
+const MAX_VARS: i32 = 1_000;
 
 fuzz_target!(|data: &[u8]| {
     let mut md = ReadStatMetadata::new();
     if md.read_metadata_from_bytes(data, false).is_err() {
+        return;
+    }
+    if md.var_count > MAX_VARS {
         return;
     }
     let row_count = (md.row_count as u32).min(MAX_ROWS);

--- a/fuzz/fuzz_targets/fuzz_read_data_filtered.rs
+++ b/fuzz/fuzz_targets/fuzz_read_data_filtered.rs
@@ -3,7 +3,7 @@ use libfuzzer_sys::fuzz_target;
 use readstat::{ReadStatData, ReadStatMetadata};
 
 use arbitrary::Arbitrary;
-use arrow::datatypes::Schema;
+use arrow::datatypes::{Field, Schema};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -14,8 +14,9 @@ struct FuzzInput<'a> {
     selected_columns: Vec<u16>,
 }
 
-// Cap rows to avoid OOM from malformed metadata claiming billions of rows.
+// Cap rows and columns to avoid OOM from malformed metadata.
 const MAX_ROWS: u32 = 100_000;
+const MAX_VARS: i32 = 1_000;
 
 fuzz_target!(|input: FuzzInput| {
     let mut md = ReadStatMetadata::new();
@@ -24,7 +25,7 @@ fuzz_target!(|input: FuzzInput| {
     }
 
     let total_var_count = md.var_count;
-    if total_var_count == 0 {
+    if total_var_count == 0 || total_var_count > MAX_VARS {
         return;
     }
 
@@ -60,9 +61,14 @@ fuzz_target!(|input: FuzzInput| {
         })
         .collect();
 
-    let filtered_fields: Vec<_> = selected
+    let filtered_fields: Vec<Field> = selected
         .iter()
-        .filter_map(|&idx| md.schema.fields().get(idx as usize).cloned())
+        .filter_map(|&idx| {
+            md.schema
+                .fields()
+                .get(idx as usize)
+                .map(|f| f.as_ref().clone())
+        })
         .collect();
 
     md.vars = filtered_vars;


### PR DESCRIPTION
## Summary
- Bump fuzz `arrow` dependency from v57 to v58 to match workspace, fixing build failure in `fuzz_read_data_filtered` (fixes #159)
- Add `MAX_VARS=1000` cap to `fuzz_read_data` and `fuzz_read_data_filtered` to prevent OOM from crafted inputs with huge `var_count` (fixes #160)
- Fix `Schema::new()` call for Arrow v58 API (`Vec<Field>` not `Vec<Arc<Field>>`)

## Test plan
- [x] `cargo check` passes in fuzz directory
- [x] `cargo test --workspace` passes
- [ ] Next scheduled fuzz run (Monday) should pass all three targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)