### PR TITLE
Scope Miri to ptr_to_string tests only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -417,7 +417,10 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
       - name: Run Miri on pure-Rust unit tests
-        run: cargo +nightly miri test -p readstat
+        # Scope to ptr_to_string: the only unsafe code (CStr::from_ptr) reachable
+        # by unit tests. FFI callbacks require the C library and can't run under Miri.
+        # Proptest suites are excluded — they're slow under Miri's interpreter.
+        run: cargo +nightly miri test -p readstat -- ptr_to_string
 
   asan-linux:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'


### PR DESCRIPTION
Running the full test suite under Miri is slow: proptest runs 256 cases per property and Miri's interpreter adds 100-1000x overhead. The only unsafe code reachable by unit tests is CStr::from_ptr in ptr_to_string; FFI callbacks require the C library and cannot run under Miri anyway.

https://claude.ai/code/session_0173bvkmpLuy3hGnLfZifXF9