### PR TITLE
Restore full unit test coverage under Miri, skip only proptest suites

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -417,10 +417,11 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
       - name: Run Miri on pure-Rust unit tests
-        # Scope to ptr_to_string: the only unsafe code (CStr::from_ptr) reachable
-        # by unit tests. FFI callbacks require the C library and can't run under Miri.
-        # Proptest suites are excluded — they're slow under Miri's interpreter.
-        run: cargo +nightly miri test -p readstat -- ptr_to_string
+        # Skip proptest suites: they run 256 cases each and are 100-1000x slower
+        # under Miri's interpreter. All proptest tests live in `property_tests`
+        # submodules. Everything else (ptr_to_string unsafe, build_offsets, err,
+        # rs_path) runs and gives Miri coverage over both unsafe and safe Rust.
+        run: cargo +nightly miri test -p readstat -- --skip property_tests
 
   asan-linux:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'

--- a/crates/readstat/src/cb.rs
+++ b/crates/readstat/src/cb.rs
@@ -458,7 +458,10 @@ pub(crate) extern "C" fn handle_value(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proptest::prelude::*;
+
+    mod property_tests {
+        use super::*;
+        use proptest::prelude::*;
 
     // --- round_decimal_f64 ---
 
@@ -573,4 +576,5 @@ mod tests {
             prop_assert_eq!(sas_secs, back);
         }
     }
+    } // end property_tests
 }


### PR DESCRIPTION
The previous change was too narrow (only ptr_to_string). The slow part was proptest running 256 cases each under Miri's 100-1000x interpreter overhead — not the plain unit tests. Move cb.rs proptest tests into a mod property_tests submodule (matching common.rs), then use --skip property_tests so Miri covers all unit tests (ptr_to_string unsafe, build_offsets, err, rs_path) while skipping the proptest suites.

https://claude.ai/code/session_0173bvkmpLuy3hGnLfZifXF9