### PR TITLE
Add versioned CLI cheatsheet to docs and mdBook

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The binary is invoked using subcommands:
 
 Column metadata &mdash; labels, SAS format strings, and storage widths &mdash; is preserved in Parquet and Feather output as Arrow field metadata. See **[docs/TECHNICAL.md](docs/TECHNICAL.md#column-metadata-in-arrow-and-parquet)** for details.
 
-For the full CLI reference &mdash; including column selection, parallelism, memory considerations, SQL queries, reader modes, and debug options &mdash; see **[docs/USAGE.md](docs/USAGE.md)**.
+For a one-page visual overview see the **[CLI Cheatsheet](docs/readstat-cheatsheet.html)** ([rendered](https://curtisalexander.github.io/readstat-rs/readstat-cheatsheet.html)).  For the full CLI reference &mdash; including column selection, parallelism, memory considerations, SQL queries, reader modes, and debug options &mdash; see **[docs/USAGE.md](docs/USAGE.md)**.
 
 For library, API server, and WebAssembly usage, see **[Examples](#bulb-examples)** below.
 
@@ -99,6 +99,7 @@ Clone the repository (with submodules), install platform-specific developer tool
 |----------|-------------|
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Crate layout, key types, and architectural patterns |
 | [docs/USAGE.md](docs/USAGE.md) | Full CLI reference and examples |
+| [docs/readstat-cheatsheet.html](docs/readstat-cheatsheet.html) | One-page printable CLI cheatsheet ([rendered](https://curtisalexander.github.io/readstat-rs/readstat-cheatsheet.html)) |
 | [docs/BUILDING.md](docs/BUILDING.md) | Clone, build, and linking details per platform |
 | [docs/TECHNICAL.md](docs/TECHNICAL.md) | Floating-point precision and date/time handling |
 | [docs/TESTING.md](docs/TESTING.md) | Running tests, dataset table, fuzz testing, valgrind |

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -6,6 +6,7 @@
 
 - [Installation & Building](building.md)
 - [CLI Usage](usage.md)
+- [CLI Cheatsheet](cheatsheet.md)
 
 # Reference
 

--- a/book/src/cheatsheet.md
+++ b/book/src/cheatsheet.md
@@ -1,0 +1,9 @@
+# CLI Cheatsheet
+
+A one-page printable visual reference for the `readstat` CLI &mdash; subcommands, flags, Parquet compression options, parallelism, reader modes, column selection, metadata round-trips, and common workflows.
+
+📄 **[Open the cheatsheet](readstat-cheatsheet.html)**
+
+The cheatsheet is intentionally high-level and complements (rather than replaces) the [full CLI reference](usage.md), which goes deeper on memory behaviour, parallel-write internals, and reading preserved metadata from Parquet/Feather output.
+
+> 💡 The cheatsheet is also designed to print cleanly in landscape on a single page.

--- a/crates/readstat-cli/README.md
+++ b/crates/readstat-cli/README.md
@@ -18,4 +18,7 @@ Binary crate producing the `readstat` CLI tool for converting SAS binary files (
 - SQL queries via DataFusion (`--sql`, feature-gated)
 - Parquet compression settings (`--compression`, `--compression-level`)
 
-For the full CLI reference, see [docs/USAGE.md](https://github.com/curtisalexander/readstat-rs/blob/main/docs/USAGE.md).
+## Documentation
+
+- [**CLI Cheatsheet**](https://curtisalexander.github.io/readstat-rs/readstat-cheatsheet.html) &mdash; one-page printable overview of subcommands, flags, and common workflows
+- [Full CLI reference (docs/USAGE.md)](https://github.com/curtisalexander/readstat-rs/blob/main/docs/USAGE.md) &mdash; complete documentation with memory diagrams and metadata round-trip examples

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -2,6 +2,8 @@
 
 # Usage
 
+> 💡 **Quick reference:** A one-page visual [**CLI Cheatsheet**](readstat-cheatsheet.html) is available for at-a-glance lookup of subcommands, flags, and common workflows.  This page is the full reference and goes deeper on memory, parallelism, and metadata round-trips.
+
 After either [building](BUILDING.md) or [installing](../README.md#install), the binary is invoked using [subcommands](https://docs.rs/clap/latest/clap/_derive/_tutorial/index.html#subcommands).  Currently, the following subcommands have been implemented:
 - `metadata` &rarr; writes the following to standard out or json
     - row count
@@ -39,6 +41,20 @@ readstat metadata /some/dir/to/example.sas7bdat --as-json
 ```
 
 The JSON output contains file-level metadata and a `vars` object keyed by variable index.  This makes it straightforward to search for a particular column by piping the output to [`jq`](https://jqlang.github.io/jq/) or Python.
+
+### Skipping the row count
+
+Computing the row count requires traversing the entire file.  If only variable-level metadata is needed (names, types, labels, formats), pass `--skip-row-count` to short-circuit row enumeration:
+
+```sh
+readstat metadata /some/dir/to/example.sas7bdat --skip-row-count
+```
+
+In that mode the reported row count is `0` and parsing returns as soon as the header and variable definitions have been read.
+
+### Suppressing the progress bar
+
+By default `metadata`, `preview`, and `data` render a progress bar while the file is being parsed.  Pass `--no-progress` (available on all three subcommands) to suppress it &mdash; useful in CI logs, when piping output, or when launching `readstat` from another process.
 
 ### Search for a column with `jq`
 
@@ -81,6 +97,12 @@ readstat preview /some/dir/to/example.sas7bdat --rows 100
 - `feather`
 - `ndjson`
 - `parquet`
+
+By default `data` refuses to overwrite an existing output file.  Pass `--overwrite` to replace it:
+
+```sh
+readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --format parquet --overwrite
+```
 
 ### `csv`
 To write parsed data (as `csv`) to a file, invoke the following (default is to write all parsed data to the specified file).

--- a/docs/readstat-cheatsheet.html
+++ b/docs/readstat-cheatsheet.html
@@ -63,6 +63,20 @@
     font-family: 'JetBrains Mono', monospace;
     letter-spacing: 0.02em;
   }
+  .version-badge {
+    display: inline-block;
+    background: #eef2ff;
+    color: #4338ca;
+    border: 1px solid #c7d2fe;
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 700;
+    font-size: 0.72rem;
+    padding: 1px 7px;
+    border-radius: 999px;
+    margin-left: 8px;
+    vertical-align: middle;
+    letter-spacing: 0.02em;
+  }
 
   /* ── Grid ── */
   .grid {
@@ -234,7 +248,7 @@
   <!-- Header -->
   <div class="header">
     <div class="header-left">
-      <h1><span>readstat</span> <span style="color:#6366f1">Cheatsheet</span></h1>
+      <h1><span>readstat</span> <span style="color:#6366f1">Cheatsheet</span><span class="version-badge">v0.22.0</span></h1>
       <div class="subtitle">Convert SAS .sas7bdat files to CSV, Feather, NDJSON, or Parquet</div>
     </div>
     <div class="header-right">
@@ -408,7 +422,7 @@
   <!-- Footer -->
   <div style="display:flex; justify-content:space-between; align-items:center; margin-top:10px; padding-top:8px; border-top:2px solid #e2e8f0; font-size:0.72rem; color:#94a3b8;">
     <span><strong style="color:#6366f1">Input:</strong> SAS <span class="cmd">.sas7bdat</span> &ensp;|&ensp; <strong style="color:#6366f1">Output:</strong> CSV, Feather, NDJSON, Parquet</span>
-    <span>Rust + ReadStat C library &ensp;|&ensp; Arrow v58 &ensp;|&ensp; <a href="https://github.com/curtisalexander/readstat-rs" style="color:#6366f1; text-decoration:none;">github.com/curtisalexander/readstat-rs</a></span>
+    <span>readstat-cli <strong style="color:#6366f1">v0.22.0</strong> &ensp;|&ensp; Rust + ReadStat C library &ensp;|&ensp; Arrow v58 &ensp;|&ensp; <a href="https://github.com/curtisalexander/readstat-rs" style="color:#6366f1; text-decoration:none;">github.com/curtisalexander/readstat-rs</a></span>
   </div>
 
 </div>

--- a/scripts/build-book.ps1
+++ b/scripts/build-book.ps1
@@ -116,6 +116,13 @@ Write-Host "Building mdBook ..."
 mdbook build (Join-Path $RepoRoot "book")
 if ($LASTEXITCODE -ne 0) { throw "mdbook build failed" }
 
+# Copy the standalone cheatsheet HTML into the book output so it is
+# served at /readstat-cheatsheet.html alongside the book pages.
+$BookOut = Join-Path $RepoRoot "target" "book"
+Write-Host "Copying CLI cheatsheet into $BookOut ..."
+Copy-Item -Force (Join-Path $RepoRoot "docs" "readstat-cheatsheet.html") `
+                 (Join-Path $BookOut "readstat-cheatsheet.html")
+
 # --------------------------------------------------------------------
 # 3. Optionally build rustdocs and copy into the book output
 # --------------------------------------------------------------------

--- a/scripts/build-book.sh
+++ b/scripts/build-book.sh
@@ -89,6 +89,12 @@ cp "$REPO_ROOT/examples/sql-explorer/README.md"  "$BOOK_SRC/examples/sql-explore
 echo "Building mdBook ..."
 mdbook build "$REPO_ROOT/book"
 
+# Copy the standalone cheatsheet HTML into the book output so it is
+# served at /readstat-cheatsheet.html alongside the book pages.
+BOOK_OUT="$REPO_ROOT/target/book"
+echo "Copying CLI cheatsheet into $BOOK_OUT/ ..."
+cp "$REPO_ROOT/docs/readstat-cheatsheet.html" "$BOOK_OUT/readstat-cheatsheet.html"
+
 # --------------------------------------------------------------------
 # 3. Optionally build rustdocs and copy into the book output
 # --------------------------------------------------------------------


### PR DESCRIPTION
- Stamp the readstat-cheatsheet.html with a v0.22.0 badge in the header
  and footer so readers know which release the cheatsheet matches.
- Reference the cheatsheet from README.md (CLI Usage blurb and the
  Documentation table) and from crates/readstat-cli/README.md.
- Cross-link the cheatsheet at the top of docs/USAGE.md, and extend
  USAGE.md to cover --skip-row-count, --no-progress, and --overwrite so
  the cheatsheet can stay high-level while USAGE.md remains the full
  reference.
- Add a CLI Cheatsheet page to the mdBook (book/src/cheatsheet.md +
  SUMMARY.md entry) and update build-book.sh / build-book.ps1 to copy
  the standalone HTML into target/book/ for GitHub Pages.