### PR TITLE
ci: add x86_64-pc-windows-gnu release build (and rename build-win to build-win-msvc)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -255,7 +255,7 @@ jobs:
             target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  build-win:
+  build-win-msvc:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
     runs-on: windows-latest
     env:


### PR DESCRIPTION
## Summary

- Adds a `build-win-gnu` release job to `main.yml` targeting `x86_64-pc-windows-gnu`, so tagged releases ship a second Windows binary (`readstat-<version>-x86_64-pc-windows-gnu.zip`) with no MSVC runtime dependency, alongside the existing MSVC zip.
- Renames the existing Windows job `build-win` → `build-win-msvc` to distinguish the two flavors. Artifact/asset names are unchanged (they derive from the target triple).

## Notes

- No new toolchain setup is required: the `windows-latest` runner image ships MinGW gcc/binutils on PATH, which rustc uses as the linker and `cc` uses for the vendored C (ReadStat, win-iconv).
- The sys crates were already windows-gnu-ready: `readstat-sys` has pre-generated `bindings_windows_gnu_x86_64.rs`, and `readstat-iconv-sys` shares one bindings file across MSVC/GNU (iconv's surface is enum-free), so no libclang is needed at build time.
- Validation: `workflow_dispatch` run [#228](https://github.com/curtisalexander/readstat-rs/actions/runs/29220322692) exercises the new job on this branch (build-only, no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrZm2eTi3wDFMmQ7wXHFdr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrZm2eTi3wDFMmQ7wXHFdr)_