### PR TITLE
Release hardening and API redesign for v0.26.0

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -6,10 +6,17 @@ on:
     - cron: "0 3 * * 1"
   workflow_dispatch:
 
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
 jobs:
   fuzz:
     name: Fuzz ${{ matrix.target }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     strategy:
       fail-fast: false
       matrix:
@@ -18,7 +25,7 @@ jobs:
           - fuzz_read_data
           - fuzz_read_data_filtered
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -28,6 +35,7 @@ jobs:
         run: cargo install cargo-fuzz
 
       - name: Run fuzzer (${{ matrix.target }})
+        id: fuzz
         run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=1800
 
       - name: Upload corpus
@@ -38,14 +46,14 @@ jobs:
           path: fuzz/corpus/${{ matrix.target }}/
 
       - name: Upload crash artifacts
-        if: failure()
+        if: failure() && steps.fuzz.outcome == 'failure' && hashFiles(format('fuzz/artifacts/{0}/**', matrix.target)) != ''
         uses: actions/upload-artifact@v7
         with:
           name: crashes-${{ matrix.target }}
           path: fuzz/artifacts/${{ matrix.target }}/
 
       - name: Open issue on crash
-        if: failure()
+        if: failure() && steps.fuzz.outcome == 'failure' && hashFiles(format('fuzz/artifacts/{0}/**', matrix.target)) != ''
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: readstat-rs
 env:
   PACKAGE_NAME: readstat
   CARGO_TERM_COLOR: always
+  RUSTDOCFLAGS: "-D warnings"
 
 on:
   # Trigger on release tag push. Only `v*` tags (readstat/readstat-cli
@@ -32,14 +33,22 @@ on:
   repository_dispatch:
     types: [build, test, release]
 
+  # Comprehensive memory-safety checks run nightly as well as before releases.
+  schedule:
+    - cron: "0 4 * * *"
+
 jobs:
-  # Required verification for branches, PRs, and tags. Release-producing jobs
-  # depend on this once rather than duplicating these heavy gates per target.
+  # Fast, required feedback for every branch, PR, and tag. SQL's expensive
+  # code generation and tests run independently below so both jobs start at
+  # once and failures are attributed to the owning subsystem.
   verify:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Check Arrow/DataFusion lockstep
@@ -52,26 +61,25 @@ jobs:
         run: sudo apt-get update -y && sudo apt-get install -y build-essential clang
       - name: Formatting
         run: cargo fmt --all -- --check
-      - name: Clippy (all targets and features)
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-      - name: Check (all targets and features)
-        run: cargo check --workspace --all-targets --all-features
+      - name: Clippy without SQL
+        run: |
+          cargo clippy -p readstat --all-targets --no-default-features --features csv,parquet,feather,ndjson -- -D warnings
+          cargo clippy -p readstat-cli --all-targets --no-default-features --features csv,parquet,feather,ndjson -- -D warnings
+          cargo clippy -p readstat-sys -p readstat-iconv-sys --all-targets -- -D warnings
+      - name: Check format features without SQL
+        run: |
+          cargo check -p readstat --all-targets --no-default-features --features csv,parquet,feather,ndjson
+          cargo check -p readstat-cli --all-targets --no-default-features --features csv,parquet,feather,ndjson
       - name: Check minimal feature builds
         run: |
           cargo check -p readstat --no-default-features
           cargo check -p readstat-cli --no-default-features
-      - name: Test (SQL is default)
-        run: cargo test --workspace --all-features
-      - name: Rustdoc
-        run: cargo doc --workspace --all-features --no-deps
+      - name: Test core library without default features
+        run: cargo test -p readstat --no-default-features
       - name: Install mdBook
         uses: taiki-e/install-action@mdbook
       - name: Build documentation book
         run: bash scripts/build-book.sh
-      - name: Check advertised API examples
-        run: |
-          cargo check --manifest-path examples/api-demo/rust-server/Cargo.toml
-          cargo check --manifest-path examples/api-demo/python-server/readstat_py/Cargo.toml
       - name: Check WASM crate on host
         run: |
           cargo fmt --manifest-path crates/readstat-wasm/Cargo.toml -- --check
@@ -82,13 +90,46 @@ jobs:
             cargo package -p "$crate" --allow-dirty --list >/dev/null
           done
 
+  # SQL is part of the default API and remains a required PR gate. Keep its
+  # full code-generation/linking cost in one Linux job instead of repeating it
+  # in every native-platform binding job. The standalone examples share this
+  # job's target directory so their default-feature builds reuse DataFusion.
+  sql:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+      - name: Install system dependencies
+        run: sudo apt-get update -y && sudo apt-get install -y build-essential clang
+      - name: Clippy with all features
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Test workspace with all features
+        run: cargo test --workspace --all-features
+      - name: Rustdoc with all features
+        run: cargo doc --workspace --all-features --no-deps
+      - name: Check advertised API examples
+        run: |
+          cargo check --manifest-path examples/api-demo/rust-server/Cargo.toml
+          cargo check --manifest-path examples/api-demo/python-server/readstat_py/Cargo.toml
+
   # The WASM crate is excluded from the workspace and needs Emscripten to link,
   # so host clippy alone cannot establish that the published JS artifact builds.
   wasm:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install Rust toolchain
@@ -100,7 +141,7 @@ jobs:
         with:
           workspaces: crates/readstat-wasm
       - name: Install Emscripten
-        uses: emscripten-core/setup-emsdk@v15
+        uses: emscripten-core/setup-emsdk@v16
       - name: Build WASM crate
         working-directory: crates/readstat-wasm
         run: cargo build --target wasm32-unknown-emscripten --release
@@ -126,11 +167,13 @@ jobs:
   # so `readstat-sys/buildtime_bindgen` stays off — it would drag in
   # bindgen/libclang, which is irrelevant to the MSRV contract.
   msrv:
-    if: "!startsWith(github.ref, 'refs/tags/')"
+    if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install MSRV toolchain
@@ -147,14 +190,14 @@ jobs:
         run: cargo check -p readstat -p readstat-cli --all-features --all-targets
 
   release-notes:
-    if: startsWith(github.ref, 'refs/tags/')
-    needs: [verify, wasm]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [verify, sql, wasm, miri, asan-linux, asan-macos, asan-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Generate changelog
@@ -212,10 +255,13 @@ jobs:
 
   build-linux-gnu:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
-    needs: [verify, wasm]
+    needs: [verify, sql, wasm, miri, asan-linux, asan-macos, asan-windows]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       target: x86_64-unknown-linux-gnu
+      RUSTFLAGS: "-D warnings"
     steps:
       - name: Get version
         id: get_version
@@ -228,7 +274,7 @@ jobs:
             echo "VERSION=${{ github.event.client_payload.version || 'dev' }}" >> $GITHUB_OUTPUT
           fi
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install toolchain
@@ -250,7 +296,7 @@ jobs:
           path: target/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
       - name: Release
         uses: softprops/action-gh-release@v3
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           files: |
             target/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
@@ -258,10 +304,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-linux-musl:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
-    needs: [verify, wasm]
+    needs: [verify, sql, wasm, miri, asan-linux, asan-macos, asan-windows]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       target: x86_64-unknown-linux-musl
+      RUSTFLAGS: "-D warnings"
     steps:
       - name: Get version
         id: get_version
@@ -274,7 +323,7 @@ jobs:
             echo "VERSION=${{ github.event.client_payload.version || 'dev' }}" >> $GITHUB_OUTPUT
           fi
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install toolchain
@@ -296,7 +345,7 @@ jobs:
           path: target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
       - name: Release
         uses: softprops/action-gh-release@v3
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           files: |
             target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
@@ -304,14 +353,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-linux-arm:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
-    needs: [verify, wasm]
+    needs: [verify, sql, wasm, miri, asan-linux, asan-macos, asan-windows]
     # Native arm64 runner (same image the readstat-sys cross-platform CI uses):
     # no cross toolchain or CC_/AR_/LINKER plumbing, and — unlike the old
     # cross-compile job — the test suite actually runs on the artifact's
     # platform before it ships.
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
     env:
       target: aarch64-unknown-linux-gnu
+      RUSTFLAGS: "-D warnings"
     steps:
       - name: Get version
         id: get_version
@@ -324,7 +376,7 @@ jobs:
             echo "VERSION=${{ github.event.client_payload.version || 'dev' }}" >> $GITHUB_OUTPUT
           fi
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install toolchain
@@ -350,7 +402,7 @@ jobs:
           path: target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
       - name: Release
         uses: softprops/action-gh-release@v3
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           files: |
             target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
@@ -358,10 +410,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-win-msvc:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
-    needs: [verify, wasm]
+    needs: [verify, sql, wasm, miri, asan-linux, asan-macos, asan-windows]
     runs-on: windows-latest
+    permissions:
+      contents: write
     env:
       target: x86_64-pc-windows-msvc
+      RUSTFLAGS: "-D warnings"
     steps:
       - name: Get version
         id: get_version
@@ -375,7 +430,7 @@ jobs:
           fi
         shell: bash
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install toolchain
@@ -395,7 +450,7 @@ jobs:
           path: target/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.zip
       - name: Release
         uses: softprops/action-gh-release@v3
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           files: |
             target/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.zip
@@ -403,15 +458,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-win-gnu:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
-    needs: [verify, wasm]
+    needs: [verify, sql, wasm, miri, asan-linux, asan-macos, asan-windows]
     # windows-gnu flavor: statically linked against the MinGW runtime, so the
     # binary has no MSVC runtime dependency. The runner image ships a MinGW
     # gcc/binutils on PATH, which rustc uses as the linker and cc uses to
     # compile the vendored C (ReadStat, win-iconv); readstat-sys has
     # pre-generated windows-gnu bindings, so no libclang is needed.
     runs-on: windows-latest
+    permissions:
+      contents: write
     env:
       target: x86_64-pc-windows-gnu
+      RUSTFLAGS: "-D warnings"
     steps:
       - name: Get version
         id: get_version
@@ -425,7 +483,7 @@ jobs:
           fi
         shell: bash
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install toolchain
@@ -445,7 +503,7 @@ jobs:
           path: target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.zip
       - name: Release
         uses: softprops/action-gh-release@v3
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           files: |
             target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.zip
@@ -453,10 +511,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-macos-x86:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
-    needs: [verify, wasm]
+    needs: [verify, sql, wasm, miri, asan-linux, asan-macos, asan-windows]
     runs-on: macos-latest
+    permissions:
+      contents: write
     env:
       target: x86_64-apple-darwin
+      RUSTFLAGS: "-D warnings"
     steps:
       - name: Get version
         id: get_version
@@ -469,7 +530,7 @@ jobs:
             echo "VERSION=${{ github.event.client_payload.version || 'dev' }}" >> $GITHUB_OUTPUT
           fi
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install toolchain
@@ -492,7 +553,7 @@ jobs:
           path: target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
       - name: Release
         uses: softprops/action-gh-release@v3
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           files: |
             target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
@@ -501,10 +562,13 @@ jobs:
 
   build-macos-arm:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
-    needs: [verify, wasm]
+    needs: [verify, sql, wasm, miri, asan-linux, asan-macos, asan-windows]
     runs-on: macos-latest
+    permissions:
+      contents: write
     env:
       target: aarch64-apple-darwin
+      RUSTFLAGS: "-D warnings"
     steps:
       - name: Get version
         id: get_version
@@ -517,7 +581,7 @@ jobs:
             echo "VERSION=${{ github.event.client_payload.version || 'dev' }}" >> $GITHUB_OUTPUT
           fi
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install toolchain
@@ -539,7 +603,7 @@ jobs:
           path: target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
       - name: Release
         uses: softprops/action-gh-release@v3
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           files: |
             target/${{ env.target }}/release/${{ env.PACKAGE_NAME }}-${{ steps.get_version.outputs.VERSION }}-${{ env.target }}.tar.gz
@@ -549,13 +613,14 @@ jobs:
   # --- Memory safety checks ---
 
   miri:
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
     env:
       MIRIFLAGS: "-Zmiri-disable-isolation"
+      RUSTFLAGS: "-D warnings"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install nightly toolchain with Miri
@@ -569,17 +634,17 @@ jobs:
         # under Miri's interpreter. All proptest tests live in `property_tests`
         # submodules. Everything else (ptr_to_string unsafe, build_offsets, err,
         # rs_path) runs and gives Miri coverage over both unsafe and safe Rust.
-        run: cargo +nightly miri test -p readstat -- --skip property_tests
+        run: cargo +nightly miri test -p readstat --no-default-features -- --skip property_tests
 
   asan-linux:
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: "-Zsanitizer=address -Clinker=clang"
+      RUSTFLAGS: "-D warnings -Zsanitizer=address -Clinker=clang"
       READSTAT_SANITIZE_ADDRESS: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install nightly toolchain
@@ -592,13 +657,13 @@ jobs:
         run: cargo +nightly test --workspace --lib --tests --bins --target x86_64-unknown-linux-gnu
 
   asan-macos:
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
     runs-on: macos-latest
     env:
-      RUSTFLAGS: "-Zsanitizer=address"
+      RUSTFLAGS: "-D warnings -Zsanitizer=address"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install nightly toolchain
@@ -611,13 +676,13 @@ jobs:
         run: cargo +nightly test --workspace --lib --tests --bins --target aarch64-apple-darwin
 
   asan-windows:
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
     runs-on: windows-latest
     env:
-      RUSTFLAGS: "-Zsanitizer=address"
+      RUSTFLAGS: "-D warnings -Zsanitizer=address"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install nightly toolchain
@@ -651,15 +716,15 @@ jobs:
   # instrumentation SHOULD work. Marked continue-on-error because this is
   # experimental — no one has publicly documented this combination working.
   asan-windows-full:
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
     runs-on: windows-latest
     continue-on-error: true
     env:
-      RUSTFLAGS: "-Zsanitizer=address"
+      RUSTFLAGS: "-D warnings -Zsanitizer=address"
       READSTAT_SANITIZE_ADDRESS: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install nightly toolchain

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,8 @@ jobs:
       - name: Install Emscripten
         uses: emscripten-core/setup-emsdk@v15
       - name: Build WASM crate
-        run: cargo build --manifest-path crates/readstat-wasm/Cargo.toml --target wasm32-unknown-emscripten --release
+        working-directory: crates/readstat-wasm
+        run: cargo build --target wasm32-unknown-emscripten --release
 
   # Enforce the MSRV declared in `[workspace.package] rust-version` (and
   # advertised in the READMEs): the workspace must at least type-check on that

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,21 @@ jobs:
       - name: Build WASM crate
         working-directory: crates/readstat-wasm
         run: cargo build --target wasm32-unknown-emscripten --release
+      - name: Smoke-test generated WASM package
+        working-directory: crates/readstat-wasm
+        run: |
+          cp target/wasm32-unknown-emscripten/release/readstat_wasm.wasm pkg/readstat_wasm.wasm
+          node --input-type=module <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { init, read_metadata } from "./pkg/readstat_wasm.js";
+
+          await init();
+          const input = readFileSync("../readstat-tests/tests/data/cars.sas7bdat");
+          const metadata = JSON.parse(read_metadata(input));
+          if (metadata.row_count <= 0 || metadata.var_count <= 0) {
+            throw new Error(`unexpected metadata: ${JSON.stringify(metadata)}`);
+          }
+          NODE
 
   # Enforce the MSRV declared in `[workspace.package] rust-version` (and
   # advertised in the READMEs): the workspace must at least type-check on that

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,9 @@ on:
     types: [build, test, release]
 
 jobs:
-  # Lightweight CI: tests only, runs on branch pushes and PRs (not on tag releases).
-  ci-test:
-    if: "!startsWith(github.ref, 'refs/tags/')"
+  # Required verification for branches, PRs, and tags. Release-producing jobs
+  # depend on this once rather than duplicating these heavy gates per target.
+  verify:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -50,8 +50,59 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Install system dependencies
         run: sudo apt-get update -y && sudo apt-get install -y build-essential clang
-      - name: Test
-        run: cargo test --workspace
+      - name: Formatting
+        run: cargo fmt --all -- --check
+      - name: Clippy (all targets and features)
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Check (all targets and features)
+        run: cargo check --workspace --all-targets --all-features
+      - name: Check minimal feature builds
+        run: |
+          cargo check -p readstat --no-default-features
+          cargo check -p readstat-cli --no-default-features
+      - name: Test (SQL is default)
+        run: cargo test --workspace --all-features
+      - name: Rustdoc
+        run: cargo doc --workspace --all-features --no-deps
+      - name: Install mdBook
+        uses: taiki-e/install-action@mdbook
+      - name: Build documentation book
+        run: bash scripts/build-book.sh
+      - name: Check advertised API examples
+        run: |
+          cargo check --manifest-path examples/api-demo/rust-server/Cargo.toml
+          cargo check --manifest-path examples/api-demo/python-server/readstat_py/Cargo.toml
+      - name: Check WASM crate on host
+        run: |
+          cargo fmt --manifest-path crates/readstat-wasm/Cargo.toml -- --check
+          cargo clippy --manifest-path crates/readstat-wasm/Cargo.toml --all-targets -- -D warnings
+      - name: Check package contents
+        run: |
+          for crate in readstat-iconv-sys readstat-sys readstat readstat-cli; do
+            cargo package -p "$crate" --allow-dirty --list >/dev/null
+          done
+
+  # The WASM crate is excluded from the workspace and needs Emscripten to link,
+  # so host clippy alone cannot establish that the published JS artifact builds.
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-emscripten
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates/readstat-wasm
+      - name: Install Emscripten
+        uses: emscripten-core/setup-emsdk@v15
+      - name: Build WASM crate
+        run: cargo build --manifest-path crates/readstat-wasm/Cargo.toml --target wasm32-unknown-emscripten --release
 
   # Enforce the MSRV declared in `[workspace.package] rust-version` (and
   # advertised in the READMEs): the workspace must at least type-check on that
@@ -81,6 +132,7 @@ jobs:
 
   release-notes:
     if: startsWith(github.ref, 'refs/tags/')
+    needs: [verify, wasm]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -144,6 +196,7 @@ jobs:
 
   build-linux-gnu:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    needs: [verify, wasm]
     runs-on: ubuntu-latest
     env:
       target: x86_64-unknown-linux-gnu
@@ -189,6 +242,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-linux-musl:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    needs: [verify, wasm]
     runs-on: ubuntu-latest
     env:
       target: x86_64-unknown-linux-musl
@@ -234,6 +288,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-linux-arm:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    needs: [verify, wasm]
     # Native arm64 runner (same image the readstat-sys cross-platform CI uses):
     # no cross toolchain or CC_/AR_/LINKER plumbing, and — unlike the old
     # cross-compile job — the test suite actually runs on the artifact's
@@ -287,6 +342,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-win-msvc:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    needs: [verify, wasm]
     runs-on: windows-latest
     env:
       target: x86_64-pc-windows-msvc
@@ -331,6 +387,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-win-gnu:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    needs: [verify, wasm]
     # windows-gnu flavor: statically linked against the MinGW runtime, so the
     # binary has no MSVC runtime dependency. The runner image ships a MinGW
     # gcc/binutils on PATH, which rustc uses as the linker and cc uses to
@@ -380,6 +437,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-macos-x86:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    needs: [verify, wasm]
     runs-on: macos-latest
     env:
       target: x86_64-apple-darwin
@@ -427,6 +485,7 @@ jobs:
 
   build-macos-arm:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    needs: [verify, wasm]
     runs-on: macos-latest
     env:
       target: aarch64-apple-darwin

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,18 +14,21 @@ concurrency:
   group: "pages"
   cancel-in-progress: true
 
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+  RUSTDOCFLAGS: "-D warnings"
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Install mdBook
-        uses: peaceiris/actions-mdbook@v2
-        with:
-          mdbook-version: "latest"
+        uses: taiki-e/install-action@mdbook
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/readstat-sys-ci.yml
+++ b/.github/workflows/readstat-sys-ci.yml
@@ -3,12 +3,12 @@ name: readstat-sys cross-platform CI
 # Runs on every PR (and direct push to main) that touches `readstat-sys`
 # itself, the vendored C sources, or this workflow. Two job matrices:
 #
-#   * `consume`: builds the workspace + runs all tests on
-#     ubuntu/macos/windows using the checked-in per-target pre-gen
-#     bindings. This is the load-bearing check — it proves the
+#   * `consume`: builds the workspace without SQL and runs focused native
+#     parser tests on ubuntu/macos/windows using the checked-in per-target
+#     pre-gen bindings. This is the load-bearing check — it proves the
 #     `bindings_<os>_<arch>.rs` files (Windows additionally keyed by
 #     env: msvc is the un-suffixed file, gnu is `bindings_windows_gnu_*`)
-#     match each platform's actual ABI.
+#     match each platform's actual ABI without compiling DataFusion six times.
 #
 #   * `regen`: runs bindgen via `--features buildtime_bindgen` to
 #     reproduce the corresponding per-target file. Uploads each result
@@ -21,6 +21,9 @@ name: readstat-sys cross-platform CI
 # bindings on demand without a PR.
 
 on:
+  schedule:
+    # Weekly comprehensive native/bindings validation.
+    - cron: "0 5 * * 0"
   pull_request:
     paths:
       - 'crates/readstat-sys/**'
@@ -43,6 +46,11 @@ on:
       - 'Cargo.lock'
       - '.github/workflows/readstat-sys-ci.yml'
   workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+  RUSTDOCFLAGS: "-D warnings"
 
 jobs:
   consume:
@@ -74,9 +82,14 @@ jobs:
             file: bindings_windows_gnu_x86_64.rs
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: consume-${{ matrix.target }}
 
       - name: Install MinGW toolchain (windows-gnu only)
         if: matrix.target == 'x86_64-pc-windows-gnu'
@@ -89,11 +102,13 @@ jobs:
         if: matrix.target == 'x86_64-pc-windows-gnu'
         run: rustup target add ${{ matrix.target }}
 
-      - name: Build with default features (consumes pre-gen ${{ matrix.file }})
-        run: cargo build --workspace --target ${{ matrix.target }}
+      - name: Build without SQL (consumes pre-gen ${{ matrix.file }})
+        run: cargo build --workspace --no-default-features --target ${{ matrix.target }}
 
-      - name: Test
-        run: cargo test --workspace --target ${{ matrix.target }}
+      - name: Test native parser and platform-sensitive encodings
+        run: |
+          cargo test -p readstat --no-default-features --target ${{ matrix.target }}
+          cargo test -p readstat-tests --no-default-features --target ${{ matrix.target }} --test parse_encoding_test --test parse_malformed_utf8_test
 
   regen:
     strategy:
@@ -120,15 +135,31 @@ jobs:
             file: bindings_windows_gnu_x86_64.rs
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: regen-${{ matrix.target }}
+
       - name: Install LLVM (Windows only — bindgen needs libclang)
         if: matrix.os == 'windows-latest'
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          version: "17"
+        shell: pwsh
+        run: |
+          choco uninstall llvm --no-progress -y
+          choco install llvm --version=17.0.6 --allow-downgrade --no-progress -y
+          $llvmBin = Join-Path $env:ProgramFiles "LLVM\bin"
+          if (!(Test-Path (Join-Path $llvmBin "libclang.dll"))) {
+            throw "libclang.dll not found in $llvmBin"
+          }
+          $clangVersion = & (Join-Path $llvmBin "clang.exe") --version
+          if ($clangVersion[0] -notmatch "17\.0\.6") {
+            throw "Expected LLVM 17.0.6, got: $($clangVersion[0])"
+          }
+          Add-Content $env:GITHUB_PATH $llvmBin
+          Add-Content $env:GITHUB_ENV "LIBCLANG_PATH=$llvmBin"
 
       - name: Install MinGW toolchain (windows-gnu only)
         if: matrix.target == 'x86_64-pc-windows-gnu'
@@ -195,14 +226,30 @@ jobs:
   regen-iconv:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - name: Install LLVM (bindgen needs libclang)
-        uses: KyleMayes/install-llvm-action@v2
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
         with:
-          version: "17"
+          key: regen-iconv-windows
+
+      - name: Install LLVM (bindgen needs libclang)
+        shell: pwsh
+        run: |
+          choco uninstall llvm --no-progress -y
+          choco install llvm --version=17.0.6 --allow-downgrade --no-progress -y
+          $llvmBin = Join-Path $env:ProgramFiles "LLVM\bin"
+          if (!(Test-Path (Join-Path $llvmBin "libclang.dll"))) {
+            throw "libclang.dll not found in $llvmBin"
+          }
+          $clangVersion = & (Join-Path $llvmBin "clang.exe") --version
+          if ($clangVersion[0] -notmatch "17\.0\.6") {
+            throw "Expected LLVM 17.0.6, got: $($clangVersion[0])"
+          }
+          Add-Content $env:GITHUB_PATH $llvmBin
+          Add-Content $env:GITHUB_ENV "LIBCLANG_PATH=$llvmBin"
 
       - name: Regenerate iconv bindings
         # READSTAT_REGEN_BINDINGS opts in to refreshing the checked-in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-07-23
+
+### Added
+- Added `CONTRIBUTING.md` as a concise workspace orientation map and expanded equivalent Unix/Windows release gates for the book, advertised API examples, WASM, packaging, and dependency policy.
+- Added a required Emscripten CI build for the standalone `readstat-wasm` crate.
+
+### Changed
+- Redesigned the primary library surface around `ReadStatReader` (path/bytes/mmap, selection, metadata/read/chunks/visit) and `WriteConfig` plus schema-bound `ReadStatWriter`; SQL sync and async APIs are enabled by default.
+- Made `readstat convert` canonical, with extension-based output inference, CSV stdout when output is omitted, strict extension/format validation, and diagnostics on stderr.
+- Strengthened normal and tag CI so all-feature verification and advertised examples pass before release artifacts are produced.
+- Made writer finalization consume the writer and publish fully finalized filesystem output from a same-directory staging file; failed conversion preserves an existing destination, and overwrite refusal remains race-free.
+- Added a discoverable bounded SQL input channel constructor; channel-backed async SQL no longer blocks Tokio workers, and async output encoding runs on a blocking worker with bounded backpressure.
+
+### Fixed
+- Reconciled release documentation around explicit tag pushes and `--allow-dirty` publishing of vendor-prepared sys crates.
+- Fixed writer row counts, zero-row output finalization, metadata parse rollback, zero-sized offset chunks, broken-pipe handling, and ineffective CLI option combinations.
+
 ## [0.25.1] - 2026-07-13
 
 Bumps `readstat` and `readstat-cli` to 0.25.1; `readstat-sys` to 0.5.1; `readstat-iconv-sys` to 0.4.1 (both sys crates' build scripts changed behavior — see the bindings regeneration note under Changed).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing orientation
+
+This is a map of the repository, not a separate set of contribution rules.
+
+- `crates/readstat`: public Rust reader/writer and SQL APIs.
+- `crates/readstat-cli`: command parsing, conversion orchestration, human metadata output, and columns-file parsing.
+- `crates/readstat-sys` / `readstat-iconv-sys`: raw C FFI and vendored builds. Normal builds consume checked-in bindings; regeneration is the explicit maintainer workflow documented in [CI-CD](docs/CI-CD.md#updating-bindgen-or-the-vendored-c--regenerating-bindings).
+- `crates/readstat-tests`: integration coverage and datasets.
+- `crates/readstat-wasm` and `fuzz`: standalone projects excluded from the workspace.
+- `examples`: independently built demos; they are not workspace members.
+
+Start with [Architecture](docs/ARCHITECTURE.md), then the README in the crate you are changing. Core checks are `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test --workspace --all-features`. Build the book with `bash scripts/build-book.sh` (PowerShell equivalent available).
+
+For release preparation, dependency order, vendoring, and tags, follow [Releasing](docs/RELEASING.md).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2511,9 +2511,9 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "readstat"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3070,11 +3070,12 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "windows-sys",
 ]
 
 [[package]]
 name = "readstat-cli"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "arrow-array",
  "arrow-csv",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The `ReadStat` library is used to parse and read `sas7bdat` files, and the `arro
 
 Convert the first 50,000 rows of `example.sas7bdat` (by performing the read in parallel) to the file `example.parquet`, overwriting the file if it already exists.
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --format parquet --rows 50000 --overwrite --parallel
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --rows 50000 --overwrite --parallel
 ```
 
 ## :package: CLI Install
@@ -74,7 +74,7 @@ readstat --help
 The binary is invoked using subcommands:
 - `metadata` &rarr; writes file and variable metadata to standard out or JSON
 - `preview` &rarr; writes the first N rows of parsed data as `csv` to standard out
-- `data` &rarr; writes parsed data in `csv`, `feather`, `ndjson`, or `parquet` format to a file
+- `convert` &rarr; converts data to CSV, Feather, NDJSON, or Parquet; the output extension selects the format, or omitted output writes CSV to stdout
 
 Column metadata &mdash; labels, SAS format strings, and storage widths &mdash; is preserved in Parquet and Feather output as Arrow field metadata. See **[docs/TECHNICAL.md](docs/TECHNICAL.md#column-metadata-in-arrow-and-parquet)** for details.
 
@@ -143,6 +143,8 @@ The [`examples/`](examples/) directory contains runnable demos showing different
 | [`sql-explorer`](examples/sql-explorer/) | Browser-based SQL explorer — upload a `.sas7bdat` file and query it interactively with SQL via AlaSQL |
 
 To use `readstat` as a library in your own Rust project, add the [`readstat`](crates/readstat/) crate as a dependency.
+
+SQL support (synchronous and asynchronous DataFusion APIs) and all four output writers are enabled by default. Disable defaults only when building a deliberately smaller library.
 
 ## :balance_scale: License
 

--- a/crates/readstat-cli/Cargo.toml
+++ b/crates/readstat-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readstat-cli"
-version = "0.25.1"
+version = "0.26.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -20,9 +20,10 @@ categories = ["command-line-utilities"]
 [[bin]]
 name = "readstat"
 path = "src/main.rs"
+doc = false
 
 [dependencies]
-readstat = { path = "../readstat", version = "0.25.1" }
+readstat = { path = "../readstat", version = "0.26.0" }
 
 arrow-array = { workspace = true }
 arrow-csv = { workspace = true, optional = true }
@@ -39,7 +40,7 @@ rayon = { workspace = true }
 tempfile = { version = "3", optional = true }
 
 [features]
-default = ["csv", "parquet", "feather", "ndjson"]
+default = ["csv", "parquet", "feather", "ndjson", "sql"]
 csv = ["readstat/csv", "dep:arrow-csv"]
 parquet = ["readstat/parquet", "dep:tempfile"]
 feather = ["readstat/feather"]

--- a/crates/readstat-cli/Cargo.toml
+++ b/crates/readstat-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-readstat = { path = "../readstat", version = "0.26.0" }
+readstat = { path = "../readstat", version = "0.26.0", default-features = false }
 
 arrow-array = { workspace = true }
 arrow-csv = { workspace = true, optional = true }

--- a/crates/readstat-cli/README.md
+++ b/crates/readstat-cli/README.md
@@ -8,15 +8,17 @@ Binary crate producing the `readstat` CLI tool for converting SAS binary files (
 
 - `metadata` — Print file metadata (row/var counts, labels, encoding, format version, etc.)
 - `preview` — Preview first N rows as CSV to stdout
-- `data` — Convert to output format (csv, feather, ndjson, parquet)
+- `convert` — Convert to CSV, Feather, NDJSON, or Parquet (inferred from the output extension)
 
 ## Key Features
 
 - Column selection (`--columns`, `--columns-file`)
 - Streaming reads with configurable chunk size (`--stream-rows`)
 - Parallel reading (`--parallel`) and parallel Parquet writing (`--parallel-write`)
-- SQL queries via DataFusion (`--sql`, feature-gated)
+- SQL queries via DataFusion (`--sql`, enabled by default)
 - Parquet compression settings (`--compression`, `--compression-level`)
+
+With no `--output`, conversion writes CSV to stdout. Progress, logs, and other diagnostics go to stderr, so stdout can be piped safely. An explicit format must agree with `.csv`, `.feather`, `.ndjson`, or `.parquet`; unknown extensions and mismatches are errors.
 
 ## Documentation
 

--- a/crates/readstat-cli/src/cli.rs
+++ b/crates/readstat-cli/src/cli.rs
@@ -42,7 +42,7 @@ pub enum ReadStatCliCommands {
         /// Type of reader{n}    mem = read all data into memory{n}    stream = read at most stream-rows into memory{n}Defaults to stream
         #[arg(value_enum, ignore_case = true, long, value_parser)]
         reader: Option<Reader>,
-        /// Number of rows to stream (read into memory) at a time{n}↑ rows = ↑ memory usage{n}Ignored if reader is set to mem{n}Defaults to 10,000 rows
+        /// Number of rows per streaming chunk (default: 10,000){n}Cannot be used with --reader mem
         #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
         stream_rows: Option<u32>,
         /// Do not display progress bar
@@ -54,24 +54,25 @@ pub enum ReadStatCliCommands {
         /// Path to a file containing column names (one per line, # comments)
         #[arg(long, value_hint = ValueHint::FilePath, conflicts_with = "columns")]
         columns_file: Option<PathBuf>,
-        /// SQL query to run against the data (requires sql feature){n}The table name is the input file stem (e.g. "cars" for cars.sas7bdat){n}Mutually exclusive with --columns/--columns-file
+        /// SQL query to run against the data{n}The table name is the input file stem (e.g. "cars" for cars.sas7bdat){n}Mutually exclusive with --columns/--columns-file
         #[cfg(feature = "sql")]
         #[arg(long, conflicts_with_all = ["columns", "columns_file"])]
         sql: Option<String>,
-        /// Path to a file containing a SQL query (requires sql feature){n}Mutually exclusive with --sql and --columns/--columns-file
+        /// Path to a file containing a SQL query{n}Mutually exclusive with --sql and --columns/--columns-file
         #[cfg(feature = "sql")]
         #[arg(long, value_hint = ValueHint::FilePath, conflicts_with_all = ["sql", "columns", "columns_file"])]
         sql_file: Option<PathBuf>,
     },
     /// Convert sas7bdat data to csv, feather (or the Arrow IPC format), ndjson, or parquet format
-    Data {
+    #[command(alias = "data")]
+    Convert {
         /// Path to sas7bdat file
         #[arg(value_hint = ValueHint::FilePath, value_parser)]
         input: PathBuf,
-        /// Output file path
+        /// Output file path; its extension determines the format when --format is omitted{n}Without an output path, CSV is written to stdout
         #[arg(long, short = 'o', value_hint = ValueHint::FilePath, value_parser)]
         output: Option<PathBuf>,
-        /// Output file format{n}Defaults to csv
+        /// Output format (normally inferred from the output extension)
         #[arg(ignore_case = true, long, short = 'f', value_enum, value_parser)]
         format: Option<CliOutFormat>,
         /// Overwrite output file if it already exists
@@ -83,7 +84,7 @@ pub enum ReadStatCliCommands {
         /// Type of reader{n}    mem = read all data into memory{n}    stream = read at most stream-rows into memory{n}Defaults to stream
         #[arg(ignore_case = true, long, value_enum, value_parser)]
         reader: Option<Reader>,
-        /// Number of rows to stream (read into memory) at a time{n}↑ rows = ↑ memory usage{n}Ignored if reader is set to mem{n}Defaults to 10,000 rows
+        /// Number of rows per streaming chunk (default: 10,000){n}Cannot be used with --reader mem
         #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
         stream_rows: Option<u32>,
         /// Do not display progress bar
@@ -92,12 +93,12 @@ pub enum ReadStatCliCommands {
         /// Convert sas7bdat data in parallel
         #[arg(action, long)]
         parallel: bool,
-        /// Write Parquet output in parallel{n}Parquet only — ignored for other formats{n}Only effective when --parallel is also enabled{n}Output row order is preserved
-        #[arg(action, long)]
+        /// Write Parquet output in parallel{n}Requires --parallel and Parquet output; preserves row order
+        #[arg(action, long, requires = "parallel")]
         parallel_write: bool,
-        /// Memory buffer size in MB before spilling to disk during parallel writes{n}Defaults to 100 MB{n}Only effective when parallel-write is enabled
-        #[arg(long, value_parser = clap::value_parser!(u64).range(1..=10240), default_value = "100")]
-        parallel_write_buffer_mb: u64,
+        /// Memory buffer size in MB before spilling to disk (default: 100){n}Requires --parallel-write
+        #[arg(long, value_parser = clap::value_parser!(u64).range(1..=10240), requires = "parallel_write")]
+        parallel_write_buffer_mb: Option<u64>,
         /// Parquet compression algorithm
         #[arg(long, value_enum, value_parser)]
         compression: Option<CliParquetCompression>,
@@ -110,11 +111,11 @@ pub enum ReadStatCliCommands {
         /// Path to a file containing column names (one per line, # comments)
         #[arg(long, value_hint = ValueHint::FilePath, conflicts_with = "columns")]
         columns_file: Option<PathBuf>,
-        /// SQL query to run against the data (requires sql feature){n}The table name is the input file stem (e.g. "cars" for cars.sas7bdat){n}Mutually exclusive with --columns/--columns-file
+        /// SQL query to run against the data{n}The table name is the input file stem (e.g. "cars" for cars.sas7bdat){n}Mutually exclusive with --columns/--columns-file and --parallel-write
         #[cfg(feature = "sql")]
         #[arg(long, conflicts_with_all = ["columns", "columns_file"])]
         sql: Option<String>,
-        /// Path to a file containing a SQL query (requires sql feature){n}Mutually exclusive with --sql and --columns/--columns-file
+        /// Path to a file containing a SQL query{n}Mutually exclusive with --sql, --columns/--columns-file, and --parallel-write
         #[cfg(feature = "sql")]
         #[arg(long, value_hint = ValueHint::FilePath, conflicts_with_all = ["sql", "columns", "columns_file"])]
         sql_file: Option<PathBuf>,

--- a/crates/readstat-cli/src/main.rs
+++ b/crates/readstat-cli/src/main.rs
@@ -8,10 +8,53 @@ mod run;
 fn main() {
     let args = cli::ReadStatCli::parse();
     if let Err(e) = run::run(args) {
+        if is_broken_pipe(&e) {
+            return;
+        }
         eprintln!("Stopping with error: {e}");
         // Exit 1 for runtime failures. clap reserves exit code 2 for
         // usage/argument errors, so keep those distinct.
         std::process::exit(1);
     }
     std::process::exit(0);
+}
+
+fn is_broken_pipe(error: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(err) = current {
+        // arrow-csv currently flattens writer I/O errors into CsvError text
+        // rather than preserving std::io::Error as a source.
+        if err
+            .downcast_ref::<readstat::arrow::error::ArrowError>()
+            .is_some_and(|error| {
+                matches!(error, readstat::arrow::error::ArrowError::CsvError(message) if message.contains("Broken pipe"))
+            })
+        {
+            return true;
+        }
+        if err
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io| io.kind() == std::io::ErrorKind::BrokenPipe)
+        {
+            return true;
+        }
+        current = err.source();
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_broken_pipe;
+
+    #[test]
+    fn recognizes_io_and_arrow_csv_broken_pipes() {
+        let io = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "closed");
+        assert!(is_broken_pipe(&io));
+
+        let arrow = readstat::arrow::error::ArrowError::CsvError(
+            "Csv error: Broken pipe (os error 32)".into(),
+        );
+        assert!(is_broken_pipe(&arrow));
+    }
 }

--- a/crates/readstat-cli/src/run/convert.rs
+++ b/crates/readstat-cli/src/run/convert.rs
@@ -177,7 +177,7 @@ pub(super) fn run(cmd: ReadStatCliCommands) -> Result<(), ReadStatError> {
     let sas_path = PathAbs::new(input)?.as_path().to_path_buf();
     debug!(
         "Generating data from the file {}",
-        &sas_path.to_string_lossy()
+        sas_path.to_string_lossy()
     );
 
     let rsp = ReadStatPath::new(sas_path)?;

--- a/crates/readstat-cli/src/run/convert.rs
+++ b/crates/readstat-cli/src/run/convert.rs
@@ -15,7 +15,10 @@ use readstat::{
     ReadStatWriter, WriteConfig, build_offsets,
 };
 
-use crate::cli::{ReadStatCli, ReadStatCliCommands, Reader};
+use super::support::resolve_columns;
+#[cfg(feature = "sql")]
+use super::support::{resolve_sql, table_name_from_path};
+use crate::cli::{ReadStatCliCommands, Reader};
 
 /// Default number of rows to read per streaming chunk.
 const STREAM_ROWS: u32 = 10000;
@@ -34,11 +37,10 @@ fn write_empty_output(
     wc: &WriteConfig,
     input_path: &std::path::Path,
 ) -> Result<(), ReadStatError> {
-    let mut d = ReadStatData::new().init_shared(var_count, vars, schema.clone(), 0, 0);
-    d.batch = Some(arrow_array::RecordBatch::new_empty(schema));
-    let mut wtr = ReadStatWriter::new();
-    wtr.write(&d, wc)?;
-    let rows = wtr.finish(&d, wc)?;
+    let _ = (var_count, vars);
+    let mut wtr = ReadStatWriter::new(wc.clone(), schema.clone())?;
+    wtr.write(&arrow_array::RecordBatch::new_empty(schema))?;
+    let rows = wtr.finish()?;
     print_write_summary(rows, input_path, wc.out_path());
     Ok(())
 }
@@ -52,7 +54,7 @@ fn print_write_summary(rows: usize, in_path: &std::path::Path, out_path: Option<
     let out_f = out_path
         .and_then(std::path::Path::file_name)
         .map_or_else(|| "___".to_string(), |f| f.to_string_lossy().to_string());
-    println!(
+    eprintln!(
         "In total, wrote {} rows from file {in_f} into {out_f}",
         format_with_commas(rows)
     );
@@ -126,217 +128,10 @@ fn create_progress(
     Ok(Some(Arc::new(IndicatifProgress { pb })))
 }
 
-/// Resolve column names from `--columns` or `--columns-file` CLI options.
-fn resolve_columns(
-    columns: Option<Vec<String>>,
-    columns_file: Option<PathBuf>,
-) -> Result<Option<Vec<String>>, ReadStatError> {
-    if let Some(path) = columns_file {
-        let names = ReadStatMetadata::parse_columns_file(&path)?;
-        if names.is_empty() {
-            // An empty columns file is almost certainly a mistake; selecting ALL
-            // columns silently would mask it. Surface it as an error instead.
-            Err(ReadStatError::EmptyColumnsFile(path))
-        } else {
-            Ok(Some(names))
-        }
-    } else {
-        Ok(columns)
-    }
-}
-
-/// Resolve the SQL query from `--sql` or `--sql-file` CLI options.
-#[cfg(feature = "sql")]
-fn resolve_sql(
-    sql: Option<String>,
-    sql_file: Option<PathBuf>,
-) -> Result<Option<String>, ReadStatError> {
-    if let Some(path) = sql_file {
-        Ok(Some(readstat::read_sql_file(&path)?))
-    } else {
-        Ok(sql)
-    }
-}
-
-/// Extract a table name from the input file stem (e.g. "cars" from "cars.sas7bdat").
-#[cfg(feature = "sql")]
-fn table_name_from_path(path: &std::path::Path) -> String {
-    path.file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("data")
-        .to_string()
-}
-
-/// Executes the CLI command specified by the parsed [`ReadStatCli`] arguments.
-///
-/// This is the main entry point for the CLI binary, dispatching to the
-/// `metadata`, `preview`, or `data` subcommand.
-pub fn run(rs: ReadStatCli) -> Result<(), ReadStatError> {
-    // Default to showing warnings (e.g. "file will be overwritten") rather than
-    // env_logger's stock `error`-only filter, under which library `warn!`s were
-    // invisible. `RUST_LOG` still overrides this.
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
-
-    match rs.command {
-        cmd @ ReadStatCliCommands::Metadata { .. } => run_metadata(cmd),
-        cmd @ ReadStatCliCommands::Preview { .. } => run_preview(cmd),
-        cmd @ ReadStatCliCommands::Data { .. } => run_data(cmd),
-    }
-}
-
-/// Handle the `metadata` subcommand: read and display SAS file metadata.
-fn run_metadata(cmd: ReadStatCliCommands) -> Result<(), ReadStatError> {
-    let ReadStatCliCommands::Metadata {
-        input: in_path,
-        as_json,
-        skip_row_count,
-    } = cmd
-    else {
-        unreachable!()
-    };
-    let sas_path = PathAbs::new(in_path)?.as_path().to_path_buf();
-    debug!(
-        "Retrieving metadata from the file {}",
-        &sas_path.to_string_lossy()
-    );
-
-    let rsp = ReadStatPath::new(sas_path)?;
-    let mut md = ReadStatMetadata::new();
-    md.read_metadata(&rsp, skip_row_count)?;
-    println!(
-        "{}",
-        ReadStatWriter::metadata_to_string(&md, &rsp, as_json)?
-    );
-    Ok(())
-}
-
-/// Handle the `preview` subcommand: read a limited number of rows and write to stdout as CSV.
-fn run_preview(cmd: ReadStatCliCommands) -> Result<(), ReadStatError> {
-    let ReadStatCliCommands::Preview {
-        input,
-        rows,
-        reader,
-        stream_rows,
-        no_progress,
-        columns,
-        columns_file,
-        #[cfg(feature = "sql")]
-        sql,
-        #[cfg(feature = "sql")]
-        sql_file,
-    } = cmd
-    else {
-        unreachable!()
-    };
-
-    #[cfg(feature = "sql")]
-    let sql_query = resolve_sql(sql, sql_file)?;
-
-    let sas_path = PathAbs::new(input)?.as_path().to_path_buf();
-    debug!(
-        "Generating data preview from the file {}",
-        &sas_path.to_string_lossy()
-    );
-
-    let rsp = ReadStatPath::new(sas_path)?;
-    let mut md = ReadStatMetadata::new();
-    md.read_metadata(&rsp, false)?;
-
-    // Resolve column selection
-    let col_names = resolve_columns(columns, columns_file)?;
-    let column_filter = md.resolve_selected_columns(col_names)?;
-    let original_var_count = md.var_count;
-    if let Some(ref mapping) = column_filter {
-        md = md.filter_to_selected_columns(mapping);
-    }
-
-    let column_filter = column_filter.map(Arc::new);
-    // try_from (not `as`): a corrupt header reporting a negative row count
-    // must surface as an error, not wrap to ~4 billion rows.
-    let total_rows_to_process = std::cmp::min(rows, u32::try_from(md.row_count)?);
-    let total_rows_to_stream = resolve_stream_rows(reader, stream_rows, total_rows_to_process);
-    let total_rows_processed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    let progress = create_progress(no_progress, total_rows_to_process)?;
-
-    let offsets = build_offsets(total_rows_to_process, total_rows_to_stream);
-    let offsets_pairs = offsets.windows(2);
-
-    let var_count = md.var_count;
-    let vars_shared = Arc::new(md.vars);
-    let schema_shared = Arc::new(md.schema);
-
-    // Signal "parsing started" once (the library no longer does this per-chunk).
-    if let Some(ref p) = progress {
-        p.parsing_started(&rsp.path.to_string_lossy());
-    }
-
-    // Read all chunks into batches
-    let mut all_batches: Vec<arrow_array::RecordBatch> = Vec::new();
-    for w in offsets_pairs {
-        let row_start = w[0];
-        let row_end = w[1];
-
-        let mut d = ReadStatData::new()
-            .set_column_filter(column_filter.clone(), original_var_count)
-            .set_total_rows_processed(total_rows_processed.clone())
-            .init_shared(
-                var_count,
-                vars_shared.clone(),
-                schema_shared.clone(),
-                row_start,
-                row_end,
-            );
-
-        if let Some(ref p) = progress {
-            d = d.set_progress(p.clone() as Arc<dyn ProgressCallback>);
-        }
-
-        d.read_data(&rsp)?;
-
-        if let Some(batch) = d.batch {
-            all_batches.push(batch);
-        }
-    }
-
-    if let Some(p) = progress {
-        p.pb.finish_with_message("Done");
-    }
-
-    // Apply SQL query if provided
-    #[cfg(feature = "sql")]
-    let all_batches = if let Some(ref query) = sql_query {
-        let table_name = table_name_from_path(&rsp.path);
-        readstat::execute_sql(all_batches, schema_shared.clone(), &table_name, query)?
-    } else {
-        all_batches
-    };
-
-    // Write all batches to stdout as CSV
-    #[cfg(feature = "csv")]
-    {
-        let stdout = std::io::stdout();
-        let mut csv_writer = arrow_csv::WriterBuilder::new()
-            .with_header(true)
-            .build(stdout);
-        for batch in &all_batches {
-            csv_writer.write(batch)?;
-        }
-    }
-    #[cfg(not(feature = "csv"))]
-    {
-        let _ = all_batches;
-        return Err(ReadStatError::Other(
-            "CSV feature is required for preview output".to_string(),
-        ));
-    }
-    #[cfg(feature = "csv")]
-    Ok(())
-}
-
-/// Handle the `data` subcommand: read SAS data and write to an output file.
+/// Handle conversion: read SAS data and write it in the selected format.
 #[allow(clippy::too_many_lines)]
-fn run_data(cmd: ReadStatCliCommands) -> Result<(), ReadStatError> {
-    let ReadStatCliCommands::Data {
+pub(super) fn run(cmd: ReadStatCliCommands) -> Result<(), ReadStatError> {
+    let ReadStatCliCommands::Convert {
         input,
         output,
         format,
@@ -367,6 +162,18 @@ fn run_data(cmd: ReadStatCliCommands) -> Result<(), ReadStatError> {
     #[cfg(feature = "sql")]
     let sql_query = resolve_sql(sql, sql_file)?;
 
+    if matches!(reader, Some(Reader::Mem)) && stream_rows.is_some() {
+        return Err(ReadStatError::Other(
+            "--stream-rows cannot be used with --reader mem".into(),
+        ));
+    }
+    if matches!(reader, Some(Reader::Mem)) && parallel {
+        return Err(ReadStatError::Other(
+            "--parallel cannot be used with --reader mem; use --reader stream or omit --reader"
+                .into(),
+        ));
+    }
+
     let sas_path = PathAbs::new(input)?.as_path().to_path_buf();
     debug!(
         "Generating data from the file {}",
@@ -374,47 +181,45 @@ fn run_data(cmd: ReadStatCliCommands) -> Result<(), ReadStatError> {
     );
 
     let rsp = ReadStatPath::new(sas_path)?;
-    let wc = WriteConfig::new(
-        output,
-        format.map(Into::into),
-        overwrite,
-        compression.map(Into::into),
-        compression_level,
-    )?;
+    let mut wc = match (output, format) {
+        (None, None) => WriteConfig::new(OutFormat::Csv),
+        (None, Some(format)) => WriteConfig::new(format.into()),
+        (Some(path), None) => WriteConfig::from_output(path)?,
+        (Some(path), Some(format)) => WriteConfig::new(format.into()).output(path)?,
+    }
+    .overwrite(overwrite);
+    if let Some(compression) = compression {
+        wc = wc.compression(compression.into(), compression_level)?;
+    }
+    if wc.out_path().is_none() && !matches!(wc.format(), OutFormat::Csv) {
+        return Err(ReadStatError::InvalidOutputConfig(
+            "only CSV may be written to stdout; provide --output for this format".into(),
+        ));
+    }
+    if parallel_write && !matches!(wc.format(), OutFormat::Parquet) {
+        return Err(ReadStatError::Other(
+            "--parallel-write is only supported for Parquet output".into(),
+        ));
+    }
+    #[cfg(feature = "sql")]
+    if parallel_write && sql_query.is_some() {
+        return Err(ReadStatError::Other(
+            "--parallel-write cannot be combined with --sql or --sql-file".into(),
+        ));
+    }
 
     let mut md = ReadStatMetadata::new();
     md.read_metadata(&rsp, false)?;
 
-    // If no output path then only read metadata; otherwise read data
+    // CSV is streamed to stdout when no output path is supplied.
     match wc.out_path() {
-        None => {
-            // A SQL query with no destination would be silently discarded —
-            // surface it as an error rather than quietly falling through to the
-            // metadata-only display.
-            #[cfg(feature = "sql")]
-            if sql_query.is_some() {
-                return Err(ReadStatError::Other(
-                    "--sql/--sql-file requires --output: the query result needs a destination file"
-                        .to_string(),
-                ));
+        None | Some(_) => {
+            if let Some(p) = wc.out_path() {
+                eprintln!(
+                    "Writing parsed data to file {}",
+                    p.to_string_lossy().bright_yellow()
+                );
             }
-
-            println!(
-                "{}: a value was not provided for the parameter {}, thus displaying metadata only\n",
-                "Warning".bright_yellow(),
-                "--output".bright_cyan()
-            );
-
-            // Column selection does not apply to a metadata-only display, so
-            // reuse the metadata already read above rather than parsing again.
-            println!("{}", ReadStatWriter::metadata_to_string(&md, &rsp, false)?);
-            Ok(())
-        }
-        Some(p) => {
-            println!(
-                "Writing parsed data to file {}",
-                p.to_string_lossy().bright_yellow()
-            );
 
             // Resolve column selection (only meaningful when writing data).
             let col_names = resolve_columns(columns, columns_file)?;
@@ -525,7 +330,7 @@ fn run_data(cmd: ReadStatCliCommands) -> Result<(), ReadStatError> {
                     // clap caps the flag at 10240 MB, so this only fails on a
                     // 32-bit usize — where >4 GiB genuinely can't be buffered.
                     let buffer_size_bytes =
-                        usize::try_from(parallel_write_buffer_mb * 1024 * 1024)?;
+                        usize::try_from(parallel_write_buffer_mb.unwrap_or(100) * 1024 * 1024)?;
                     write_parallel_parquet(ctx, buffer_size_bytes)?;
                 }
                 #[cfg(not(feature = "parquet"))]
@@ -547,7 +352,7 @@ fn run_data(cmd: ReadStatCliCommands) -> Result<(), ReadStatError> {
     }
 }
 
-/// Inputs to the reader thread spawned by [`run_data`].
+/// Inputs to the conversion reader thread.
 ///
 /// Bundles the parse configuration so [`spawn_reader`] takes a single named
 /// value rather than a long positional argument list.
@@ -655,7 +460,7 @@ fn spawn_reader(
     })
 }
 
-/// State shared by every write strategy in [`run_data`].
+/// State shared by every conversion write strategy.
 ///
 /// Owns the channel receiver and the reader-thread handle so it can move into
 /// whichever strategy runs. The metadata fields (`var_count`, `vars`, `schema`)
@@ -704,26 +509,28 @@ fn write_sequential(ctx: WriteContext) -> Result<(), ReadStatError> {
         schema,
     } = ctx;
 
-    let mut wtr = ReadStatWriter::new();
+    let mut wtr = ReadStatWriter::new(wc.clone(), schema.clone())?;
 
     // Each chunk replaces `last`, dropping the previous chunk's RecordBatch
     // memory; `last` is kept so `finish` can report the row total after the
     // channel drains.
-    let mut last: Option<(ReadStatData, WriteConfig)> = None;
-    for (d, chunk_wc, _pairs_cnt) in rx.iter() {
-        wtr.write(&d, &chunk_wc)?;
-        last = Some((d, chunk_wc));
+    let mut wrote_any = false;
+    for (d, _chunk_wc, _pairs_cnt) in rx.iter() {
+        if let Some(batch) = &d.batch {
+            wtr.write(batch)?;
+            wrote_any = true;
+        }
     }
 
     // Check the reader result before finalizing the output file.
     join_reader(reader)?;
 
-    match last {
-        Some((d, chunk_wc)) => {
-            let rows = wtr.finish(&d, &chunk_wc)?;
-            print_write_summary(rows, &input_path, chunk_wc.out_path());
+    match wrote_any {
+        true => {
+            let rows = wtr.finish()?;
+            print_write_summary(rows, &input_path, wc.out_path());
         }
-        None => {
+        false => {
             // Zero rows: still produce a valid header-only/empty file.
             write_empty_output(var_count, vars, schema, &wc, &input_path)?;
         }
@@ -751,7 +558,7 @@ fn write_parallel_parquet(
     } = ctx;
 
     let out_path = wc.out_path().map(std::path::Path::to_path_buf);
-    let compression = wc.compression();
+    let compression = wc.compression_codec();
     let compression_level = wc.compression_level();
 
     let temp_dir = if let Some(out_path) = &out_path {
@@ -829,6 +636,7 @@ fn write_parallel_parquet(
                         compression,
                         compression_level,
                         buffer_size_bytes,
+                        false,
                     )?;
                 }
 
@@ -858,6 +666,7 @@ fn write_parallel_parquet(
                 .expect("schema must be set when temp files exist"),
             compression,
             compression_level,
+            wc.is_overwrite(),
         )?;
         print_write_summary(total_rows, &input_path, Some(out_path));
     }
@@ -886,16 +695,15 @@ fn write_with_sql(ctx: WriteContext, query: &str, table_name: &str) -> Result<()
 
     join_reader(reader)?;
 
-    let results = readstat::execute_sql(all_batches, schema, table_name, query)?;
-    if let Some(out_path) = wc.out_path() {
-        readstat::write_sql_results(
-            &results,
-            out_path,
-            wc.format(),
-            wc.compression(),
-            wc.compression_level(),
-        )?;
+    let results = readstat::execute_sql(all_batches, schema.clone(), table_name, query)?;
+    let result_schema = results
+        .first()
+        .map_or_else(|| schema, arrow_array::RecordBatch::schema);
+    let mut writer = ReadStatWriter::new(wc, result_schema)?;
+    for batch in &results {
+        writer.write(batch)?;
     }
+    writer.finish()?;
 
     Ok(())
 }

--- a/crates/readstat-cli/src/run/metadata.rs
+++ b/crates/readstat-cli/src/run/metadata.rs
@@ -1,0 +1,76 @@
+//! Metadata command output.
+
+use crate::cli::ReadStatCliCommands;
+use log::debug;
+use path_abs::{PathAbs, PathInfo};
+use readstat::{ReadStatError, ReadStatMetadata, ReadStatPath};
+
+fn metadata_to_string(
+    md: &ReadStatMetadata,
+    rsp: &ReadStatPath,
+    as_json: bool,
+) -> Result<String, ReadStatError> {
+    if as_json {
+        return md.to_json();
+    }
+    use std::fmt::Write;
+    let mut out = format!("Metadata for the file {}\n\n", rsp.path.display());
+    let _ = writeln!(out, "Row count: {}", md.row_count);
+    let _ = writeln!(out, "Variable count: {}", md.var_count);
+    let _ = writeln!(out, "Table name: {}", md.table_name);
+    let _ = writeln!(out, "Table label: {}", md.file_label);
+    let _ = writeln!(out, "File encoding: {}", md.file_encoding);
+    let _ = writeln!(out, "Format version: {}", md.version);
+    let _ = writeln!(
+        out,
+        "Bitness: {}",
+        if md.is_64bit { "64-bit" } else { "32-bit" }
+    );
+    let _ = writeln!(out, "Creation time: {}", md.creation_time);
+    let _ = writeln!(out, "Modified time: {}", md.modified_time);
+    let _ = writeln!(out, "Compression: {:#?}", md.compression);
+    let _ = writeln!(out, "Byte order: {:#?}", md.endianness);
+    let _ = writeln!(out, "Variable names:");
+    for (i, var) in &md.vars {
+        let format_class = var
+            .var_format_class
+            .as_ref()
+            .map_or("", |class| match class {
+                readstat::ReadStatVarFormatClass::Date => "Date",
+                readstat::ReadStatVarFormatClass::DateTime
+                | readstat::ReadStatVarFormatClass::DateTimeWithMilliseconds
+                | readstat::ReadStatVarFormatClass::DateTimeWithMicroseconds
+                | readstat::ReadStatVarFormatClass::DateTimeWithNanoseconds => "DateTime",
+                readstat::ReadStatVarFormatClass::Time
+                | readstat::ReadStatVarFormatClass::TimeWithMilliseconds
+                | readstat::ReadStatVarFormatClass::TimeWithMicroseconds
+                | readstat::ReadStatVarFormatClass::TimeWithNanoseconds => "Time",
+                _ => "",
+            });
+        let data_type = md.schema.fields[*i as usize].data_type();
+        let _ = writeln!(
+            out,
+            "{i}: {} {{ type class: {:#?}, type: {:#?}, label: {}, format class: {format_class}, format: {}, arrow data type: {data_type:#?} }}",
+            var.var_name, var.var_type_class, var.var_type, var.var_label, var.var_format
+        );
+    }
+    Ok(out)
+}
+
+pub(super) fn run(cmd: ReadStatCliCommands) -> Result<(), ReadStatError> {
+    let ReadStatCliCommands::Metadata {
+        input,
+        as_json,
+        skip_row_count,
+    } = cmd
+    else {
+        unreachable!()
+    };
+    let sas_path = PathAbs::new(input)?.as_path().to_path_buf();
+    debug!("Retrieving metadata from the file {}", sas_path.display());
+    let rsp = ReadStatPath::new(sas_path)?;
+    let mut md = ReadStatMetadata::new();
+    md.read_metadata(&rsp, skip_row_count)?;
+    println!("{}", metadata_to_string(&md, &rsp, as_json)?);
+    Ok(())
+}

--- a/crates/readstat-cli/src/run/mod.rs
+++ b/crates/readstat-cli/src/run/mod.rs
@@ -1,0 +1,18 @@
+//! CLI command dispatch.
+
+mod convert;
+mod metadata;
+mod preview;
+mod support;
+
+use crate::cli::{ReadStatCli, ReadStatCliCommands};
+use readstat::ReadStatError;
+
+pub fn run(cli: ReadStatCli) -> Result<(), ReadStatError> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
+    match cli.command {
+        cmd @ ReadStatCliCommands::Metadata { .. } => metadata::run(cmd),
+        cmd @ ReadStatCliCommands::Preview { .. } => preview::run(cmd),
+        cmd @ ReadStatCliCommands::Convert { .. } => convert::run(cmd),
+    }
+}

--- a/crates/readstat-cli/src/run/preview.rs
+++ b/crates/readstat-cli/src/run/preview.rs
@@ -1,0 +1,121 @@
+//! Preview command orchestration.
+
+use std::sync::Arc;
+
+use path_abs::PathAbs;
+use readstat::{ProgressCallback, ReadStatError, ReadStatReader};
+
+use crate::cli::{ReadStatCliCommands, Reader};
+
+use super::support::resolve_columns;
+#[cfg(feature = "sql")]
+use super::support::{resolve_sql, table_name_from_path};
+
+pub(super) fn run(cmd: ReadStatCliCommands) -> Result<(), ReadStatError> {
+    let ReadStatCliCommands::Preview {
+        input,
+        rows,
+        reader: reader_mode,
+        stream_rows,
+        no_progress,
+        columns,
+        columns_file,
+        #[cfg(feature = "sql")]
+        sql,
+        #[cfg(feature = "sql")]
+        sql_file,
+    } = cmd
+    else {
+        unreachable!()
+    };
+
+    if matches!(reader_mode, Some(Reader::Mem)) && stream_rows.is_some() {
+        return Err(ReadStatError::Other(
+            "--stream-rows cannot be used with --reader mem".into(),
+        ));
+    }
+
+    let path = PathAbs::new(input)?.as_path().to_path_buf();
+    let reader = ReadStatReader::from_path(&path)?;
+    let available = u32::try_from(reader.metadata()?.row_count)?;
+    let selected_rows = rows.min(available);
+    let mut read = reader.rows(0, Some(selected_rows));
+    if let Some(columns) = resolve_columns(columns, columns_file)? {
+        read = read.columns(columns);
+    }
+    if !matches!(reader_mode, Some(Reader::Mem)) {
+        read = read.chunk_rows(stream_rows.unwrap_or(10_000));
+    }
+
+    let progress = (!no_progress).then(|| Arc::new(PreviewProgress::new(selected_rows)));
+    if let Some(progress) = &progress {
+        read = read.progress(progress.clone() as Arc<dyn ProgressCallback>);
+    }
+
+    let batch = read.read()?;
+    if let Some(progress) = progress {
+        progress.bar.finish_with_message("Done");
+    }
+
+    #[cfg(feature = "sql")]
+    let batches = if let Some(query) = resolve_sql(sql, sql_file)? {
+        let schema = batch.schema();
+        readstat::execute_sql(vec![batch], schema, &table_name_from_path(&path), &query)?
+    } else {
+        vec![batch]
+    };
+
+    #[cfg(not(feature = "sql"))]
+    let batches = vec![batch];
+
+    #[cfg(feature = "csv")]
+    {
+        let stdout = std::io::stdout();
+        let mut writer = arrow_csv::WriterBuilder::new()
+            .with_header(true)
+            .build(stdout);
+        for batch in &batches {
+            writer.write(batch)?;
+        }
+    }
+    #[cfg(not(feature = "csv"))]
+    {
+        let _ = batches;
+        return Err(ReadStatError::Other(
+            "CSV support is required for preview output".into(),
+        ));
+    }
+    #[cfg(feature = "csv")]
+    Ok(())
+}
+
+struct PreviewProgress {
+    bar: indicatif::ProgressBar,
+}
+
+impl PreviewProgress {
+    fn new(rows: u32) -> Self {
+        let bar = indicatif::ProgressBar::new(u64::from(rows));
+        bar.set_style(
+            indicatif::ProgressStyle::default_bar()
+                .template(
+                    "[{spinner:.green} {elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} rows {msg}",
+                )
+                .expect("static progress template is valid")
+                .progress_chars("##-"),
+        );
+        Self { bar }
+    }
+}
+
+impl ProgressCallback for PreviewProgress {
+    fn inc(&self, rows: u64) {
+        self.bar.inc(rows);
+    }
+
+    fn parsing_started(&self, path: &str) {
+        self.bar.set_message(format!("Parsing {path}"));
+        self.bar
+            .enable_steady_tick(std::time::Duration::from_millis(120));
+    }
+}

--- a/crates/readstat-cli/src/run/support.rs
+++ b/crates/readstat-cli/src/run/support.rs
@@ -1,0 +1,49 @@
+//! Small input helpers shared by preview and conversion.
+
+#[cfg(feature = "sql")]
+use std::path::Path;
+use std::path::PathBuf;
+
+use readstat::ReadStatError;
+
+pub(super) fn resolve_columns(
+    columns: Option<Vec<String>>,
+    columns_file: Option<PathBuf>,
+) -> Result<Option<Vec<String>>, ReadStatError> {
+    if let Some(path) = columns_file {
+        let contents = std::fs::read_to_string(&path)?;
+        let names = contents
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        if names.is_empty() {
+            Err(ReadStatError::EmptyColumnsFile(path))
+        } else {
+            Ok(Some(names))
+        }
+    } else {
+        Ok(columns)
+    }
+}
+
+#[cfg(feature = "sql")]
+pub(super) fn resolve_sql(
+    sql: Option<String>,
+    sql_file: Option<PathBuf>,
+) -> Result<Option<String>, ReadStatError> {
+    if let Some(path) = sql_file {
+        Ok(Some(readstat::read_sql_file(&path)?))
+    } else {
+        Ok(sql)
+    }
+}
+
+#[cfg(feature = "sql")]
+pub(super) fn table_name_from_path(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("data")
+        .to_owned()
+}

--- a/crates/readstat-sys/build.rs
+++ b/crates/readstat-sys/build.rs
@@ -88,13 +88,6 @@ fn main() {
 
     cc.include(&src).warnings(false);
 
-    // Rust links cdylibs as Emscripten side modules, whose static inputs must
-    // use position-independent relocations. `cc` does not infer PIC for this
-    // target, so request it explicitly for the vendored ReadStat objects.
-    if is_emscripten {
-        cc.pic(true);
-    }
-
     // AddressSanitizer: instrument ReadStat C code when requested.
     // Uses a targeted env var so third-party sys crates (e.g. zstd-sys)
     // are not affected — global CFLAGS would break their linking.

--- a/crates/readstat-sys/build.rs
+++ b/crates/readstat-sys/build.rs
@@ -88,6 +88,13 @@ fn main() {
 
     cc.include(&src).warnings(false);
 
+    // Rust links cdylibs as Emscripten side modules, whose static inputs must
+    // use position-independent relocations. `cc` does not infer PIC for this
+    // target, so request it explicitly for the vendored ReadStat objects.
+    if is_emscripten {
+        cc.pic(true);
+    }
+
     // AddressSanitizer: instrument ReadStat C code when requested.
     // Uses a targeted env var so third-party sys crates (e.g. zstd-sys)
     // are not affected — global CFLAGS would break their linking.

--- a/crates/readstat-tests/Cargo.toml
+++ b/crates/readstat-tests/Cargo.toml
@@ -19,7 +19,11 @@ assert_fs = "1.1"
 escargot = "0.5"
 predicates = "3"
 proptest = "1"
-readstat = { path = "../readstat" }
+readstat = {
+    path = "../readstat",
+    default-features = false,
+    features = ["csv", "parquet", "feather", "ndjson"],
+}
 
 [features]
 default = ["sql"]

--- a/crates/readstat-tests/Cargo.toml
+++ b/crates/readstat-tests/Cargo.toml
@@ -22,6 +22,7 @@ proptest = "1"
 readstat = { path = "../readstat" }
 
 [features]
+default = ["sql"]
 sql = ["readstat/sql"]
 
 [[test]]

--- a/crates/readstat-tests/tests/cli.rs
+++ b/crates/readstat-tests/tests/cli.rs
@@ -35,7 +35,7 @@ fn readstat_cmd() -> Command {
 }
 
 #[test]
-fn cli_file_does_not_exist() {
+fn data_alias_reports_missing_input() {
     let mut cmd = readstat_cmd();
     cmd.arg("data").arg("tests/data/adataset.sas7bdat");
     cmd.assert().failure().stderr(

--- a/crates/readstat-tests/tests/cli_data_csv.rs
+++ b/crates/readstat-tests/tests/cli_data_csv.rs
@@ -70,12 +70,12 @@ fn cars_to_csv() {
     let tempfile = NamedTempFile::new("cars.csv").unwrap();
     let mut cmd = readstat_cmd();
 
-    cmd.arg("data")
+    cmd.arg("convert")
         .arg("tests/data/cars.sas7bdat")
         .args(["--format", "csv"])
         .args(["--output", tempfile.as_os_str().to_str().unwrap()]);
 
-    cmd.assert().success().stdout(predicate::str::contains(
+    cmd.assert().success().stderr(predicate::str::contains(
         "In total, wrote 1,081 rows from file cars.sas7bdat into cars.csv",
     ));
 
@@ -96,13 +96,13 @@ fn cars_to_csv_with_streaming() {
     let tempfile = NamedTempFile::new("cars_streaming.csv").unwrap();
     let mut cmd = readstat_cmd();
 
-    cmd.arg("data")
+    cmd.arg("convert")
         .arg("tests/data/cars.sas7bdat")
         .args(["--format", "csv"])
         .args(["--output", tempfile.as_os_str().to_str().unwrap()])
         .args(["--stream-rows", "500"]);
 
-    cmd.assert().success().stdout(predicate::str::contains(
+    cmd.assert().success().stderr(predicate::str::contains(
         "In total, wrote 1,081 rows from file cars.sas7bdat into",
     ));
 
@@ -124,7 +124,7 @@ fn cars_to_csv_overwrite() {
 
     // First write
     let mut cmd = readstat_cmd();
-    cmd.arg("data")
+    cmd.arg("convert")
         .arg("tests/data/cars.sas7bdat")
         .args(["--format", "csv"])
         .args(["--output", tempfile.as_os_str().to_str().unwrap()]);
@@ -132,7 +132,7 @@ fn cars_to_csv_overwrite() {
 
     // Overwrite
     let mut cmd = readstat_cmd();
-    cmd.arg("data")
+    cmd.arg("convert")
         .arg("tests/data/cars.sas7bdat")
         .args(["--format", "csv"])
         .args(["--output", tempfile.as_os_str().to_str().unwrap()])

--- a/crates/readstat-tests/tests/cli_data_parquet.rs
+++ b/crates/readstat-tests/tests/cli_data_parquet.rs
@@ -49,299 +49,39 @@ fn cli_data_to_parquet(
     compression_level: Option<u32>,
 ) -> Result<(Command, NamedTempFile), Box<dyn std::error::Error>> {
     let mut cmd = readstat_cmd();
-    let tempfile = match (overwrite, rows_to_stream, compression, compression_level) {
-        // Overwrite | Streaming | No Compression | No Compression Level
-        (OverwriteOption::Overwrite(tempfile), Some(rows), None, None) => {
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--stream-rows", rows.to_string().as_str()])
-                .arg("--overwrite");
-
-            tempfile
-        }
-        // Do Not Overwrite | Streaming | No Compression | No Compression Level
-        (OverwriteOption::DoNotOverwrite, Some(rows), None, None) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--stream-rows", rows.to_string().as_str()]);
-
-            tempfile
-        }
-        // Overwrite | No Streaming | No Compression | No Compression Level
-        (OverwriteOption::Overwrite(tempfile), None, None, None) => {
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .arg("--overwrite");
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | No Compression | No Compression Level
-        (OverwriteOption::DoNotOverwrite, None, None, None) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()]);
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | Uncompressed | No Compression Level
-        (OverwriteOption::DoNotOverwrite, None, Some(ParquetCompression::Uncompressed), None) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--compression", "uncompressed"]);
-
-            tempfile
-        }
-        // Do Not Overwrite | Streaming | Uncompressed | No Compression Level
-        (
-            OverwriteOption::DoNotOverwrite,
-            Some(rows),
-            Some(ParquetCompression::Uncompressed),
-            None,
-        ) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--stream-rows", rows.to_string().as_str()])
-                .args(["--compression", "uncompressed"]);
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | Uncompressed | Compression Level
-        (
-            OverwriteOption::DoNotOverwrite,
-            None,
-            Some(ParquetCompression::Uncompressed),
-            Some(cl),
-        ) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--compression", "uncompressed"])
-                .args(["--compression-level", cl.to_string().as_str()]);
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | Snappy | No Compression Level
-        (OverwriteOption::DoNotOverwrite, None, Some(ParquetCompression::Snappy), None) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--compression", "snappy"]);
-
-            tempfile
-        }
-        // Do Not Overwrite | Streaming | Snappy | No Compression Level
-        (OverwriteOption::DoNotOverwrite, Some(rows), Some(ParquetCompression::Snappy), None) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--stream-rows", rows.to_string().as_str()])
-                .args(["--compression", "snappy"]);
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | Snappy | Compression Level
-        (OverwriteOption::DoNotOverwrite, None, Some(ParquetCompression::Snappy), Some(cl)) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--compression", "snappy"])
-                .args(["--compression-level", cl.to_string().as_str()]);
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | Lz4Raw | No Compression Level
-        (OverwriteOption::DoNotOverwrite, None, Some(ParquetCompression::Lz4Raw), None) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--compression", "lz4-raw"]);
-
-            tempfile
-        }
-        // Do Not Overwrite | Streaming | Lz4Raw | No Compression Level
-        (OverwriteOption::DoNotOverwrite, Some(rows), Some(ParquetCompression::Lz4Raw), None) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--stream-rows", rows.to_string().as_str()])
-                .args(["--compression", "lz4-raw"]);
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | Lz4Raw | Compression Level
-        (OverwriteOption::DoNotOverwrite, None, Some(ParquetCompression::Lz4Raw), Some(cl)) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--compression", "lz4-raw"])
-                .args(["--compression-level", cl.to_string().as_str()]);
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | Gzip | Compression Level
-        (OverwriteOption::DoNotOverwrite, None, Some(ParquetCompression::Gzip), Some(cl)) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--compression", "gzip"])
-                .args(["--compression-level", cl.to_string().as_str()]);
-
-            tempfile
-        }
-        // Do Not Overwrite | Streaming | Gzip | Compression Level
-        (OverwriteOption::DoNotOverwrite, Some(rows), Some(ParquetCompression::Gzip), Some(cl)) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--stream-rows", rows.to_string().as_str()])
-                .args(["--compression", "gzip"])
-                .args(["--compression-level", cl.to_string().as_str()]);
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | Gzip | No Compression Level
-        (OverwriteOption::DoNotOverwrite, None, Some(ParquetCompression::Gzip), None) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--compression", "gzip"]);
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | Brotli | Compression Level
-        (OverwriteOption::DoNotOverwrite, None, Some(ParquetCompression::Brotli), Some(cl)) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--compression", "brotli"])
-                .args(["--compression-level", cl.to_string().as_str()]);
-
-            tempfile
-        }
-        // Do Not Overwrite | Streaming | Brotli | Compression Level
-        (
-            OverwriteOption::DoNotOverwrite,
-            Some(rows),
-            Some(ParquetCompression::Brotli),
-            Some(cl),
-        ) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--stream-rows", rows.to_string().as_str()])
-                .args(["--compression", "brotli"])
-                .args(["--compression-level", cl.to_string().as_str()]);
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | Brotli | No Compression Level
-        (OverwriteOption::DoNotOverwrite, None, Some(ParquetCompression::Brotli), None) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--compression", "brotli"]);
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | Zstd | Compression Level
-        (OverwriteOption::DoNotOverwrite, None, Some(ParquetCompression::Zstd), Some(cl)) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--compression", "zstd"])
-                .args(["--compression-level", cl.to_string().as_str()]);
-
-            tempfile
-        }
-        // Do Not Overwrite | Streaming | Zstd | Compression Level
-        (OverwriteOption::DoNotOverwrite, Some(rows), Some(ParquetCompression::Zstd), Some(cl)) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--stream-rows", rows.to_string().as_str()])
-                .args(["--compression", "zstd"])
-                .args(["--compression-level", cl.to_string().as_str()]);
-
-            tempfile
-        }
-        // Do Not Overwrite | No Streaming | Zstd | No Compression Level
-        (OverwriteOption::DoNotOverwrite, None, Some(ParquetCompression::Zstd), None) => {
-            let tempfile = NamedTempFile::new(format!("{base_file_name}.parquet"))?;
-
-            cmd.arg("data")
-                .arg(format!("tests/data/{base_file_name}.sas7bdat"))
-                .args(["--format", "parquet"])
-                .args(["--output", tempfile.as_os_str().to_str().unwrap()])
-                .args(["--compression", "zstd"]);
-
-            tempfile
-        }
-        _ => unreachable!(),
+    let (tempfile, overwrite) = match overwrite {
+        OverwriteOption::Overwrite(tempfile) => (tempfile, true),
+        OverwriteOption::DoNotOverwrite => (
+            NamedTempFile::new(format!("{base_file_name}.parquet"))?,
+            false,
+        ),
     };
+
+    cmd.arg("convert")
+        .arg(format!("tests/data/{base_file_name}.sas7bdat"))
+        .args(["--output", tempfile.as_os_str().to_str().unwrap()]);
+
+    if let Some(rows) = rows_to_stream {
+        cmd.args(["--stream-rows", &rows.to_string()]);
+    }
+    if let Some(compression) = compression {
+        let compression = match compression {
+            ParquetCompression::Uncompressed => "uncompressed",
+            ParquetCompression::Snappy => "snappy",
+            ParquetCompression::Gzip => "gzip",
+            ParquetCompression::Brotli => "brotli",
+            ParquetCompression::Lz4Raw => "lz4-raw",
+            ParquetCompression::Zstd => "zstd",
+            _ => unreachable!("unsupported Parquet compression in CLI test"),
+        };
+        cmd.args(["--compression", compression]);
+    }
+    if let Some(level) = compression_level {
+        cmd.args(["--compression-level", &level.to_string()]);
+    }
+    if overwrite {
+        cmd.arg("--overwrite");
+    }
 
     Ok((cmd, tempfile))
 }
@@ -354,14 +94,21 @@ fn parquet_shape(path: PathBuf) -> Result<(usize, usize), Box<dyn std::error::Er
     Ok((num_rows, num_cols))
 }
 
+fn assert_conversion_success(cmd: &mut Command) {
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains(
+            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
+        ));
+}
+
 #[test]
 fn cars_to_parquet() {
     if let Ok((mut cmd, tempfile)) =
         cli_data_to_parquet("cars", OverwriteOption::DoNotOverwrite, None, None, None)
     {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -381,9 +128,7 @@ fn cars_to_parquet_with_streaming() {
         None,
         None,
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -404,9 +149,7 @@ fn cars_to_parquet_overwrite() {
         None,
         None,
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         // next do not stream
         let (mut cmd, tempfile) = cli_data_to_parquet(
@@ -418,9 +161,7 @@ fn cars_to_parquet_overwrite() {
         )
         .unwrap();
 
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -440,9 +181,7 @@ fn cars_to_parquet_with_compression_uncompressed() {
         Some(ParquetCompression::Uncompressed),
         None,
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -454,7 +193,7 @@ fn cars_to_parquet_with_compression_uncompressed() {
 }
 
 #[test]
-fn cars_to_parquet_with_compression_uncompressed_with_compression_level() {
+fn cars_to_parquet_rejects_compression_level_for_uncompressed() {
     if let Ok((mut cmd, tempfile)) = cli_data_to_parquet(
         "cars",
         OverwriteOption::DoNotOverwrite,
@@ -462,7 +201,12 @@ fn cars_to_parquet_with_compression_uncompressed_with_compression_level() {
         Some(ParquetCompression::Uncompressed),
         Some(5),
     ) {
-        cmd.assert().success();
+        cmd.assert()
+            .failure()
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::contains(
+                "Stopping with error: compression codec uncompressed does not support a level",
+            ));
 
         tempfile.close().unwrap();
     }
@@ -477,9 +221,7 @@ fn cars_to_parquet_with_streaming_with_compression_uncompressed() {
         Some(ParquetCompression::Uncompressed),
         None,
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -499,9 +241,7 @@ fn cars_to_parquet_with_compression_snappy() {
         Some(ParquetCompression::Snappy),
         None,
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -521,9 +261,7 @@ fn cars_to_parquet_with_streaming_with_compression_snappy() {
         Some(ParquetCompression::Snappy),
         None,
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -535,7 +273,7 @@ fn cars_to_parquet_with_streaming_with_compression_snappy() {
 }
 
 #[test]
-fn cars_to_parquet_with_compression_snappy_with_compression_level() {
+fn cars_to_parquet_rejects_compression_level_for_snappy() {
     if let Ok((mut cmd, tempfile)) = cli_data_to_parquet(
         "cars",
         OverwriteOption::DoNotOverwrite,
@@ -543,7 +281,12 @@ fn cars_to_parquet_with_compression_snappy_with_compression_level() {
         Some(ParquetCompression::Snappy),
         Some(5),
     ) {
-        cmd.assert().success();
+        cmd.assert()
+            .failure()
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::contains(
+                "Stopping with error: compression codec snappy does not support a level",
+            ));
 
         tempfile.close().unwrap();
     }
@@ -558,9 +301,7 @@ fn cars_to_parquet_with_compression_lz4raw() {
         Some(ParquetCompression::Lz4Raw),
         None,
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -580,9 +321,7 @@ fn cars_to_parquet_with_streaming_with_compression_lz4raw() {
         Some(ParquetCompression::Lz4Raw),
         None,
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -594,7 +333,7 @@ fn cars_to_parquet_with_streaming_with_compression_lz4raw() {
 }
 
 #[test]
-fn cars_to_parquet_with_compression_lz4raw_with_compression_level() {
+fn cars_to_parquet_rejects_compression_level_for_lz4raw() {
     if let Ok((mut cmd, tempfile)) = cli_data_to_parquet(
         "cars",
         OverwriteOption::DoNotOverwrite,
@@ -602,7 +341,12 @@ fn cars_to_parquet_with_compression_lz4raw_with_compression_level() {
         Some(ParquetCompression::Lz4Raw),
         Some(5),
     ) {
-        cmd.assert().success();
+        cmd.assert()
+            .failure()
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::contains(
+                "Stopping with error: compression codec lz4-raw does not support a level",
+            ));
 
         tempfile.close().unwrap();
     }
@@ -617,9 +361,7 @@ fn cars_to_parquet_with_compression_gzip_level_5() {
         Some(ParquetCompression::Gzip),
         Some(5),
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -639,9 +381,7 @@ fn cars_to_parquet_with_streaming_with_compression_gzip_level_5() {
         Some(ParquetCompression::Gzip),
         Some(5),
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -697,9 +437,7 @@ fn cars_to_parquet_with_compression_brotli_level_5() {
         Some(ParquetCompression::Brotli),
         Some(5),
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -719,9 +457,7 @@ fn cars_to_parquet_with_streaming_with_compression_brotli_level_5() {
         Some(ParquetCompression::Brotli),
         Some(5),
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -777,9 +513,7 @@ fn cars_to_parquet_with_compression_zstd_level_5() {
         Some(ParquetCompression::Zstd),
         Some(5),
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -799,9 +533,7 @@ fn cars_to_parquet_with_sreaming_with_compression_zstd_level_5() {
         Some(ParquetCompression::Zstd),
         Some(5),
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 
@@ -821,9 +553,7 @@ fn cars_to_parquet_with_compression_zstd_level_12() {
         Some(ParquetCompression::Zstd),
         Some(12),
     ) {
-        cmd.assert().success().stdout(predicate::str::contains(
-            "In total, wrote 1,081 rows from file cars.sas7bdat into cars.parquet",
-        ));
+        assert_conversion_success(&mut cmd);
 
         let (height, width) = parquet_shape(tempfile.to_path_buf()).unwrap();
 

--- a/crates/readstat-tests/tests/cli_robustness_test.rs
+++ b/crates/readstat-tests/tests/cli_robustness_test.rs
@@ -3,6 +3,7 @@
 
 use assert_cmd::Command;
 use assert_fs::NamedTempFile;
+use predicates::prelude::*;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
@@ -31,14 +32,12 @@ fn zero_rows_csv_creates_header_only_file() {
     let tempfile = NamedTempFile::new("zero.csv").unwrap();
 
     readstat_cmd()
-        .arg("data")
+        .arg("convert")
         .arg("tests/data/cars.sas7bdat")
         .arg("--rows")
         .arg("0")
         .arg("--output")
         .arg(tempfile.path())
-        .arg("--format")
-        .arg("csv")
         .arg("--overwrite")
         .assert()
         .success();
@@ -56,14 +55,12 @@ fn zero_rows_parquet_creates_valid_empty_file() {
     let tempfile = NamedTempFile::new("zero.parquet").unwrap();
 
     readstat_cmd()
-        .arg("data")
+        .arg("convert")
         .arg("tests/data/cars.sas7bdat")
         .arg("--rows")
         .arg("0")
         .arg("--output")
         .arg(tempfile.path())
-        .arg("--format")
-        .arg("parquet")
         .arg("--overwrite")
         .assert()
         .success();
@@ -84,20 +81,37 @@ fn zero_rows_feather_creates_valid_empty_file() {
     let tempfile = NamedTempFile::new("zero.feather").unwrap();
 
     readstat_cmd()
-        .arg("data")
+        .arg("convert")
         .arg("tests/data/cars.sas7bdat")
         .arg("--rows")
         .arg("0")
         .arg("--output")
         .arg(tempfile.path())
-        .arg("--format")
-        .arg("feather")
         .arg("--overwrite")
         .assert()
         .success();
 
     let bytes = std::fs::read(tempfile.path()).unwrap();
     assert!(bytes.starts_with(b"ARROW1"), "missing Arrow IPC file magic");
+}
+
+/// Extension inference also covers NDJSON; an empty result is an empty file.
+#[test]
+fn zero_rows_ndjson_creates_valid_empty_file() {
+    let tempfile = NamedTempFile::new("zero.ndjson").unwrap();
+
+    readstat_cmd()
+        .arg("convert")
+        .arg("tests/data/cars.sas7bdat")
+        .arg("--rows")
+        .arg("0")
+        .arg("--output")
+        .arg(tempfile.path())
+        .arg("--overwrite")
+        .assert()
+        .success();
+
+    assert!(std::fs::read(tempfile.path()).unwrap().is_empty());
 }
 
 /// A file that fails mid-parse must exit nonzero — never report success over
@@ -109,9 +123,10 @@ fn truncated_input_exits_nonzero() {
     std::fs::write(truncated.path(), &data[..data.len() / 2]).unwrap();
 
     let out = NamedTempFile::new("truncated_out.parquet").unwrap();
+    std::fs::write(out.path(), b"existing destination").unwrap();
 
     readstat_cmd()
-        .arg("data")
+        .arg("convert")
         .arg(truncated.path())
         .arg("--output")
         .arg(out.path())
@@ -120,4 +135,31 @@ fn truncated_input_exits_nonzero() {
         .arg("--overwrite")
         .assert()
         .failure();
+
+    assert_eq!(
+        std::fs::read(out.path()).unwrap(),
+        b"existing destination",
+        "a failed conversion must not damage the previous destination"
+    );
+}
+
+#[test]
+fn ineffective_option_combinations_are_rejected() {
+    let input = "tests/data/cars.sas7bdat";
+
+    readstat_cmd()
+        .args(["convert", input, "--reader", "mem", "--parallel"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--parallel cannot be used with --reader mem",
+        ));
+
+    readstat_cmd()
+        .args(["convert", input, "--format", "parquet"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "only CSV may be written to stdout",
+        ));
 }

--- a/crates/readstat-tests/tests/column_select_test.rs
+++ b/crates/readstat-tests/tests/column_select_test.rs
@@ -147,24 +147,6 @@ fn column_order_preserved_from_dataset() {
 }
 
 #[test]
-fn parse_columns_file() {
-    let temp_dir = std::env::temp_dir();
-    let columns_file = temp_dir.join("test_columns.txt");
-
-    std::fs::write(
-        &columns_file,
-        "# Columns to extract\nBrand\n\n# Another comment\nModel\n  EngineSize  \n",
-    )
-    .unwrap();
-
-    let names = ReadStatMetadata::parse_columns_file(&columns_file).unwrap();
-    assert_eq!(names, vec!["Brand", "Model", "EngineSize"]);
-
-    // Clean up
-    let _ = std::fs::remove_file(&columns_file);
-}
-
-#[test]
 fn column_select_with_streaming() {
     // Test column selection with row offsets (simulating streaming)
     let rsp = common::setup_path("cars.sas7bdat").unwrap();

--- a/crates/readstat-tests/tests/convenience_api_test.rs
+++ b/crates/readstat-tests/tests/convenience_api_test.rs
@@ -1,7 +1,12 @@
 //! Runtime tests for the high-level convenience API: the `read_metadata` /
 //! `read_to_batch` free functions and `ReadStatData::init_filtered`.
 
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+use readstat::{ProgressCallback, ReadStatError, ReadStatReader};
 
 fn data_path(ds: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -72,4 +77,147 @@ fn init_filtered_selects_only_requested_columns() {
     assert_eq!(batch.num_columns(), 1);
     assert_eq!(batch.num_rows() as u32, row_count);
     assert_eq!(batch.schema().field(0).name(), &first_col);
+}
+
+#[test]
+fn reader_sources_metadata_filter_ranges_and_chunks() {
+    let path = data_path("cars.sas7bdat");
+    let bytes: Arc<[u8]> = std::fs::read(&path).unwrap().into();
+    let path_reader = ReadStatReader::from_path(&path).unwrap();
+    let metadata = path_reader.metadata().unwrap();
+    let all = path_reader.read().unwrap();
+    assert_eq!(all.num_rows(), metadata.row_count as usize);
+
+    let from_bytes = ReadStatReader::from_bytes(bytes).read().unwrap();
+    let from_mmap = ReadStatReader::from_mmap(&path).unwrap().read().unwrap();
+    assert_eq!(from_bytes, all);
+    assert_eq!(from_mmap, all);
+
+    let selected = ReadStatReader::from_path(&path)
+        .unwrap()
+        .columns(["Brand", "CityMPG"])
+        .rows(2, Some(7))
+        .chunk_rows(3);
+    let chunks = selected.chunks().unwrap();
+    assert_eq!(
+        chunks.iter().map(|b| b.num_rows()).collect::<Vec<_>>(),
+        [3, 3, 1]
+    );
+    let batch = selected.read().unwrap();
+    assert_eq!(batch.num_rows(), 7);
+    assert_eq!(batch.schema().field(0).name(), "Brand");
+    assert_eq!(batch.schema().field(1).name(), "CityMPG");
+}
+
+#[derive(Default)]
+struct Progress {
+    increments: Mutex<Vec<u64>>,
+    starts: Mutex<Vec<String>>,
+}
+
+impl ProgressCallback for Progress {
+    fn inc(&self, n: u64) {
+        self.increments.lock().unwrap().push(n);
+    }
+
+    fn parsing_started(&self, source: &str) {
+        self.starts.lock().unwrap().push(source.to_owned());
+    }
+}
+
+#[test]
+fn reader_visit_is_bounded_ordered_and_reports_actual_rows() {
+    let progress = Arc::new(Progress::default());
+    let mut seen = Vec::new();
+    ReadStatReader::from_path(data_path("cars.sas7bdat"))
+        .unwrap()
+        .rows(1, Some(5))
+        .chunk_rows(2)
+        .progress(progress.clone())
+        .visit(|batch| {
+            assert!(batch.num_rows() <= 2);
+            seen.push(batch);
+            Ok(())
+        })
+        .unwrap();
+    assert_eq!(
+        seen.iter().map(|b| b.num_rows()).collect::<Vec<_>>(),
+        [2, 2, 1]
+    );
+    assert_eq!(*progress.increments.lock().unwrap(), [2, 2, 1]);
+    assert_eq!(progress.starts.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn reader_rejects_invalid_configuration_and_handles_zero_rows_and_columns() {
+    let path = data_path("cars.sas7bdat");
+    assert!(matches!(
+        ReadStatReader::from_path(&path)
+            .unwrap()
+            .chunk_rows(0)
+            .read(),
+        Err(ReadStatError::InvalidChunkSize)
+    ));
+    assert!(matches!(
+        ReadStatReader::from_path(&path)
+            .unwrap()
+            .rows(u32::MAX, None)
+            .read(),
+        Err(ReadStatError::InvalidRowRange { .. })
+    ));
+    assert!(matches!(
+        ReadStatReader::from_path(&path)
+            .unwrap()
+            .rows(0, Some(u32::MAX))
+            .read(),
+        Err(ReadStatError::InvalidRowRange { .. })
+    ));
+    let empty = ReadStatReader::from_path(&path)
+        .unwrap()
+        .rows(0, Some(0))
+        .read()
+        .unwrap();
+    assert_eq!(empty.num_rows(), 0);
+    let no_columns = ReadStatReader::from_path(path)
+        .unwrap()
+        .columns(Vec::<String>::new())
+        .rows(0, Some(3))
+        .read()
+        .unwrap();
+    assert_eq!((no_columns.num_rows(), no_columns.num_columns()), (3, 0));
+}
+
+#[test]
+fn metadata_reuse_is_transactional_on_failure() {
+    let path = data_path("cars.sas7bdat");
+    let rsp = readstat::ReadStatPath::new(path).unwrap();
+    let mut metadata = readstat::ReadStatMetadata::new();
+    metadata.read_metadata(&rsp, false).unwrap();
+    let before = (
+        metadata.row_count,
+        metadata.var_count,
+        metadata.schema.clone(),
+    );
+    assert!(
+        metadata
+            .read_metadata_from_bytes(b"not a SAS file", false)
+            .is_err()
+    );
+    assert_eq!(
+        (
+            metadata.row_count,
+            metadata.var_count,
+            metadata.schema.clone()
+        ),
+        before
+    );
+    metadata.read_metadata(&rsp, false).unwrap();
+    assert_eq!(
+        (
+            metadata.row_count,
+            metadata.var_count,
+            metadata.schema.clone()
+        ),
+        before
+    );
 }

--- a/crates/readstat-tests/tests/parallel_write_cli_test.rs
+++ b/crates/readstat-tests/tests/parallel_write_cli_test.rs
@@ -48,7 +48,7 @@ fn test_parallel_write_cli_option() {
 
     // Run the CLI with parallel write enabled
     let mut cmd = readstat_cmd();
-    cmd.arg("data")
+    cmd.arg("convert")
         .arg(&test_data_path)
         .arg("--output")
         .arg(output_file.path())
@@ -81,7 +81,7 @@ fn test_parallel_write_buffer_size_cli_option() {
 
     // Run the CLI with custom buffer size
     let mut cmd = readstat_cmd();
-    cmd.arg("data")
+    cmd.arg("convert")
         .arg(&test_data_path)
         .arg("--output")
         .arg(output_file.path())
@@ -116,7 +116,7 @@ fn test_parallel_write_buffer_size_default() {
 
     // Run the CLI without specifying buffer size (should use default 100 MB)
     let mut cmd = readstat_cmd();
-    cmd.arg("data")
+    cmd.arg("convert")
         .arg(&test_data_path)
         .arg("--output")
         .arg(output_file.path())
@@ -147,7 +147,7 @@ fn test_parallel_write_buffer_size_small() {
         .join("all_types.sas7bdat");
 
     let mut cmd = readstat_cmd();
-    cmd.arg("data")
+    cmd.arg("convert")
         .arg(&test_data_path)
         .arg("--output")
         .arg(output_file.path())
@@ -179,7 +179,7 @@ fn test_parallel_write_buffer_size_large() {
         .join("all_types.sas7bdat");
 
     let mut cmd = readstat_cmd();
-    cmd.arg("data")
+    cmd.arg("convert")
         .arg(&test_data_path)
         .arg("--output")
         .arg(output_file.path())
@@ -200,8 +200,9 @@ fn test_parallel_write_buffer_size_large() {
 }
 
 #[test]
-fn test_parallel_write_without_parallel_reads() {
-    // Test that parallel-write works even without parallel reads
+fn test_parallel_write_requires_parallel_reads() {
+    // Parallel writes without parallel reads are rejected instead of silently
+    // ignoring the requested mode.
     let temp = assert_fs::TempDir::new().unwrap();
     let output_file = temp.child("output.parquet");
 
@@ -211,7 +212,7 @@ fn test_parallel_write_without_parallel_reads() {
         .join("all_types.sas7bdat");
 
     let mut cmd = readstat_cmd();
-    cmd.arg("data")
+    cmd.arg("convert")
         .arg(&test_data_path)
         .arg("--output")
         .arg(output_file.path())
@@ -220,11 +221,9 @@ fn test_parallel_write_without_parallel_reads() {
         .arg("--parallel-write")
         .arg("--overwrite");
 
-    let assert = cmd.assert();
-    assert.success();
-
-    // Note: parallel-write is only effective with --parallel, so this should use sequential write
-    output_file.assert(predicates::path::exists());
+    cmd.assert()
+        .failure()
+        .stderr(predicates::str::contains("--parallel"));
 
     temp.close().unwrap();
 }

--- a/crates/readstat-tests/tests/parallel_write_test.rs
+++ b/crates/readstat-tests/tests/parallel_write_test.rs
@@ -76,6 +76,7 @@ fn test_parallel_write_parquet_basic() {
                 None,
                 None,
                 100 * 1024 * 1024, // 100 MB buffer
+                false,
             )
             .unwrap();
             temp_files.push(temp_file);
@@ -83,7 +84,8 @@ fn test_parallel_write_parquet_basic() {
     }
 
     // Merge temp files
-    ReadStatWriter::merge_parquet_files(&temp_files, &output_path, &schema, None, None).unwrap();
+    ReadStatWriter::merge_parquet_files(&temp_files, &output_path, &schema, None, None, false)
+        .unwrap();
 
     // Verify the output file exists and is valid
     assert!(output_path.exists());
@@ -149,6 +151,7 @@ fn test_parallel_write_parquet_out_of_order() {
                 None,
                 None,
                 100 * 1024 * 1024, // 100 MB buffer
+                false,
             )
             .unwrap();
 
@@ -157,7 +160,8 @@ fn test_parallel_write_parquet_out_of_order() {
     }
 
     // Merge temp files (they were written out of order)
-    ReadStatWriter::merge_parquet_files(&temp_files, &output_path, schema, None, None).unwrap();
+    ReadStatWriter::merge_parquet_files(&temp_files, &output_path, schema, None, None, false)
+        .unwrap();
 
     // Verify the output file exists and is valid
     assert!(output_path.exists());
@@ -209,6 +213,7 @@ fn test_parallel_write_parquet_with_compression() {
             Some(readstat::ParquetCompression::Snappy),
             None,
             100 * 1024 * 1024, // 100 MB buffer
+            false,
         )
         .unwrap();
 
@@ -250,6 +255,46 @@ fn test_parallel_write_parquet_with_compression() {
 }
 
 #[test]
+fn single_batch_parallel_helper_honors_overwrite() {
+    let rsp_in = common::setup_path("cars.sas7bdat").unwrap();
+    let mut md = ReadStatMetadata::new();
+    md.read_metadata(&rsp_in, false).unwrap();
+    let mut data = ReadStatData::new().init(md.clone(), 0, 1);
+    data.read_data(&rsp_in).unwrap();
+    let batch = data.batch.as_ref().unwrap();
+
+    let output_path = setup_test_output("parallel_write_overwrite.parquet");
+    std::fs::write(&output_path, b"sentinel").unwrap();
+    let result = ReadStatWriter::write_batch_to_parquet(
+        batch,
+        &data.schema,
+        &output_path,
+        None,
+        None,
+        1024,
+        false,
+    );
+    assert!(matches!(
+        result,
+        Err(readstat::ReadStatError::OutputFileExists(_))
+    ));
+    assert_eq!(std::fs::read(&output_path).unwrap(), b"sentinel");
+
+    ReadStatWriter::write_batch_to_parquet(
+        batch,
+        &data.schema,
+        &output_path,
+        None,
+        None,
+        1024,
+        true,
+    )
+    .unwrap();
+    assert_eq!(&std::fs::read(&output_path).unwrap()[..4], b"PAR1");
+    cleanup_test_output(&output_path);
+}
+
+#[test]
 fn test_bufwriter_optimization_verification() {
     // This test verifies that BufWriter is being used by checking that writes complete successfully
     // The performance benefit would be measured in benchmarks
@@ -273,6 +318,7 @@ fn test_bufwriter_optimization_verification() {
             None,
             None,
             100 * 1024 * 1024, // 100 MB buffer
+            false,
         )
         .unwrap();
 
@@ -305,6 +351,7 @@ fn test_spooled_tempfile_small_buffer() {
             None,
             None,
             1024, // Only 1 KB buffer - should spill to disk
+            false,
         )
         .unwrap();
 
@@ -346,6 +393,7 @@ fn test_spooled_tempfile_large_buffer() {
             None,
             None,
             1024 * 1024 * 1024, // 1 GB buffer - should stay in memory
+            false,
         )
         .unwrap();
 

--- a/crates/readstat-tests/tests/sql_query_test.rs
+++ b/crates/readstat-tests/tests/sql_query_test.rs
@@ -10,7 +10,7 @@
 #![cfg(feature = "sql")]
 
 use arrow_array::{Array, Float64Array};
-use readstat::{ReadStatData, ReadStatMetadata, ReadStatPath};
+use readstat::{ReadStatData, ReadStatMetadata};
 use std::sync::Arc;
 
 mod common;
@@ -207,10 +207,7 @@ fn sql_read_empty_sql_file_returns_error() {
 // ── Streaming SQL tests ─────────────────────────────────────────────
 
 /// Helper: send cars data through a crossbeam channel, returns (receiver, schema).
-fn send_cars_via_channel() -> (
-    crossbeam::channel::Receiver<(ReadStatData, ReadStatPath, usize)>,
-    arrow_schema::SchemaRef,
-) {
+fn send_cars_via_channel() -> (readstat::RecordBatchReceiver, arrow_schema::SchemaRef) {
     let rsp = common::setup_path("cars.sas7bdat").unwrap();
     let mut md = ReadStatMetadata::new();
     md.read_metadata(&rsp, false).unwrap();
@@ -221,7 +218,7 @@ fn send_cars_via_channel() -> (
     d.read_data(&rsp).unwrap();
 
     let (s, r) = crossbeam::channel::bounded(10);
-    s.send((d, rsp, 1)).unwrap();
+    s.send(Ok(d.batch.expect("cars batch"))).unwrap();
     drop(s); // close the channel
 
     (r, schema)
@@ -306,14 +303,10 @@ fn sql_stream_and_write() {
     let temp_dir = std::env::temp_dir();
     let out_path = temp_dir.join("sql_stream_test_output.parquet");
 
-    let write_config = readstat::WriteConfig::new(
-        Some(out_path.clone()),
-        Some(readstat::OutFormat::Parquet),
-        true,
-        None,
-        None,
-    )
-    .unwrap();
+    let write_config = readstat::WriteConfig::new(readstat::OutFormat::Parquet)
+        .output(out_path.clone())
+        .unwrap()
+        .overwrite(true);
 
     readstat::execute_sql_and_write_stream(
         receiver,
@@ -347,14 +340,10 @@ fn sql_stream_and_write_zero_rows() {
     let temp_dir = std::env::temp_dir();
     let out_path = temp_dir.join("sql_stream_test_zero_rows.parquet");
 
-    let write_config = readstat::WriteConfig::new(
-        Some(out_path.clone()),
-        Some(readstat::OutFormat::Parquet),
-        true,
-        None,
-        None,
-    )
-    .unwrap();
+    let write_config = readstat::WriteConfig::new(readstat::OutFormat::Parquet)
+        .output(out_path.clone())
+        .unwrap()
+        .overwrite(true);
 
     readstat::execute_sql_and_write_stream(
         receiver,

--- a/crates/readstat-wasm/.cargo/config.toml
+++ b/crates/readstat-wasm/.cargo/config.toml
@@ -1,3 +1,8 @@
+[env]
+# Rust emits this cdylib as an Emscripten side module. Every native archive in
+# the final link (including transitive format codecs) must therefore use PIC.
+CFLAGS_wasm32_unknown_emscripten = "-fPIC"
+
 [target.wasm32-unknown-emscripten]
 rustflags = [
     "-Clink-arg=-sALLOW_MEMORY_GROWTH=1",

--- a/crates/readstat-wasm/.cargo/config.toml
+++ b/crates/readstat-wasm/.cargo/config.toml
@@ -1,10 +1,8 @@
-[env]
-# Rust emits this cdylib as an Emscripten side module. Every native archive in
-# the final link (including transitive format codecs) must therefore use PIC.
-CFLAGS_wasm32_unknown_emscripten = "-fPIC"
-
 [target.wasm32-unknown-emscripten]
 rustflags = [
+    # Rust defaults Emscripten cdylibs to dynamic side modules. This package is
+    # loaded directly by its JS wrapper, so emit a standalone main module.
+    "-Clink-arg=-sSIDE_MODULE=0",
     "-Clink-arg=-sALLOW_MEMORY_GROWTH=1",
     "-Clink-arg=-sERROR_ON_UNDEFINED_SYMBOLS=0",
     "-Clink-arg=--no-entry",

--- a/crates/readstat-wasm/.cargo/config.toml
+++ b/crates/readstat-wasm/.cargo/config.toml
@@ -1,5 +1,6 @@
 [target.wasm32-unknown-emscripten]
 rustflags = [
+    "-Dwarnings",
     # Rust defaults Emscripten cdylibs to dynamic side modules. This package is
     # loaded directly by its JS wrapper, so emit a standalone main module.
     "-Clink-arg=-sSIDE_MODULE=0",

--- a/crates/readstat-wasm/src/lib.rs
+++ b/crates/readstat-wasm/src/lib.rs
@@ -1,5 +1,5 @@
 use readstat::{
-    ReadStatData, ReadStatMetadata, write_batch_to_csv_bytes, write_batch_to_ndjson_bytes,
+    ReadStatMetadata, ReadStatReader, write_batch_to_csv_bytes, write_batch_to_ndjson_bytes,
 };
 use readstat::{write_batch_to_feather_bytes, write_batch_to_parquet_bytes};
 use std::ffi::CString;
@@ -124,10 +124,20 @@ unsafe fn read_metadata_inner(ptr: *const u8, len: usize, skip_row_count: bool) 
     // We also checked for null/zero above.
     let bytes = unsafe { slice::from_raw_parts(ptr, len) };
 
-    let mut md = ReadStatMetadata::new();
-    if md.read_metadata_from_bytes(bytes, skip_row_count).is_err() {
-        return std::ptr::null_mut();
-    }
+    let md = if skip_row_count {
+        // The high-level reader intentionally always computes the exact row count.
+        // Keep the low-level metadata call for this fast-path export only.
+        let mut md = ReadStatMetadata::new();
+        if md.read_metadata_from_bytes(bytes, true).is_err() {
+            return std::ptr::null_mut();
+        }
+        md
+    } else {
+        let Ok(md) = ReadStatReader::from_bytes(bytes).metadata() else {
+            return std::ptr::null_mut();
+        };
+        md
+    };
 
     match serde_json::to_string(&md) {
         Ok(json) => match CString::new(json) {
@@ -157,28 +167,13 @@ unsafe fn read_data_inner(ptr: *const u8, len: usize, format: &OutputFormat) -> 
     // We also checked for null/zero above.
     let bytes = unsafe { slice::from_raw_parts(ptr, len) };
 
-    // First pass: read metadata
-    let mut md = ReadStatMetadata::new();
-    if md.read_metadata_from_bytes(bytes, false).is_err() {
-        return std::ptr::null_mut();
-    }
-
-    #[allow(clippy::cast_sign_loss)]
-    let row_count = md.row_count as u32;
-
-    // Second pass: read data
-    let mut d = ReadStatData::new().init(md, 0, row_count);
-    if d.read_data_from_bytes(bytes).is_err() {
-        return std::ptr::null_mut();
-    }
-
-    let Some(batch) = &d.batch else {
+    let Ok(batch) = ReadStatReader::from_bytes(bytes).read() else {
         return std::ptr::null_mut();
     };
 
     let output_bytes = match format {
-        OutputFormat::Csv => write_batch_to_csv_bytes(batch),
-        OutputFormat::Ndjson => write_batch_to_ndjson_bytes(batch),
+        OutputFormat::Csv => write_batch_to_csv_bytes(&batch),
+        OutputFormat::Ndjson => write_batch_to_ndjson_bytes(&batch),
     };
 
     match output_bytes {
@@ -204,28 +199,13 @@ unsafe fn read_data_binary_inner(
     // We also checked for null/zero above.
     let bytes = unsafe { slice::from_raw_parts(ptr, len) };
 
-    // First pass: read metadata
-    let mut md = ReadStatMetadata::new();
-    if md.read_metadata_from_bytes(bytes, false).is_err() {
-        return std::ptr::null_mut();
-    }
-
-    #[allow(clippy::cast_sign_loss)]
-    let row_count = md.row_count as u32;
-
-    // Second pass: read data
-    let mut d = ReadStatData::new().init(md, 0, row_count);
-    if d.read_data_from_bytes(bytes).is_err() {
-        return std::ptr::null_mut();
-    }
-
-    let Some(batch) = &d.batch else {
+    let Ok(batch) = ReadStatReader::from_bytes(bytes).read() else {
         return std::ptr::null_mut();
     };
 
     let output_bytes = match format {
-        BinaryOutputFormat::Parquet => write_batch_to_parquet_bytes(batch),
-        BinaryOutputFormat::Feather => write_batch_to_feather_bytes(batch),
+        BinaryOutputFormat::Parquet => write_batch_to_parquet_bytes(&batch),
+        BinaryOutputFormat::Feather => write_batch_to_feather_bytes(&batch),
     };
 
     match output_bytes {

--- a/crates/readstat/Cargo.toml
+++ b/crates/readstat/Cargo.toml
@@ -48,7 +48,6 @@ log = { workspace = true }
 num-derive = "0.4"
 num-traits = "0.2"
 regex = "1.12"
-readstat-sys = { path = "../readstat-sys", version = "0.5.1" }
 serde = { workspace = true }
 serde_json = "1"
 thiserror = "2"
@@ -79,6 +78,14 @@ optional = true
 memmap2 = "0.9"
 path_abs = { workspace = true }
 rayon = { workspace = true }
+
+[target.'cfg(not(target_os = "emscripten"))'.dependencies]
+readstat-sys = { path = "../readstat-sys", version = "0.5.1" }
+
+# Emscripten has no portable pre-generated bindings because its sysroot is part
+# of emsdk. Enable target-local generation automatically for WASM consumers.
+[target.'cfg(target_os = "emscripten")'.dependencies]
+readstat-sys = { path = "../readstat-sys", version = "0.5.1", features = ["buildtime_bindgen"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }

--- a/crates/readstat/Cargo.toml
+++ b/crates/readstat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readstat"
-version = "0.25.1"
+version = "0.26.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -54,13 +54,12 @@ serde_json = "1"
 thiserror = "2"
 
 [features]
-default = ["csv", "parquet", "feather", "ndjson"]
+default = ["csv", "parquet", "feather", "ndjson", "sql"]
 csv = ["dep:arrow-csv"]
 parquet = ["dep:parquet", "dep:tempfile"]
 feather = ["dep:arrow-ipc"]
 ndjson = ["dep:arrow-json"]
-# `sql` writes query results in any output format, so it requires all four
-# format writers (rs_query.rs uses arrow-csv/ipc/json and parquet directly).
+# SQL output delegates to ReadStatWriter, so enable its supported formats.
 sql = ["dep:datafusion", "dep:tokio", "dep:futures", "csv", "parquet", "feather", "ndjson"]
 
 [dependencies.datafusion]
@@ -69,7 +68,7 @@ optional = true
 
 [dependencies.tokio]
 version = "1"
-features = ["rt-multi-thread"]
+features = ["rt-multi-thread", "sync"]
 optional = true
 
 [dependencies.futures]
@@ -80,6 +79,9 @@ optional = true
 memmap2 = "0.9"
 path_abs = { workspace = true }
 rayon = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/readstat/README.md
+++ b/crates/readstat/README.md
@@ -8,11 +8,15 @@ Rust library for parsing SAS binary files (`.sas7bdat`) into Apache Arrow `Recor
 
 ## Quick Start
 
-Read an entire file into a single Arrow `RecordBatch`:
+Configure a reader from a path (or use `from_bytes` / `from_mmap`) and read an entire file into one Arrow `RecordBatch`:
 
 ```rust,no_run
 fn main() -> Result<(), readstat::ReadStatError> {
-    let batch = readstat::read_to_batch("data.sas7bdat")?;
+    let reader = readstat::ReadStatReader::from_path("data.sas7bdat")?
+        .rows(0, None)
+        .columns(["Make", "Model"])
+        .chunk_rows(10_000);
+    let batch = reader.read()?;
     println!("{} rows x {} columns", batch.num_rows(), batch.num_columns());
     Ok(())
 }
@@ -22,13 +26,14 @@ Or read just the file/variable metadata, without loading any rows:
 
 ```rust,no_run
 fn main() -> Result<(), readstat::ReadStatError> {
-    let md = readstat::read_metadata("data.sas7bdat")?;
+    let reader = readstat::ReadStatReader::from_path("data.sas7bdat")?;
+    let md = reader.metadata()?;
     println!("{} rows x {} columns", md.row_count, md.var_count);
     Ok(())
 }
 ```
 
-For streaming large files in chunks, parallel reads, and column filtering, use the `ReadStatPath` / `ReadStatMetadata` / `ReadStatData` types directly — see the [crate documentation](https://docs.rs/readstat).
+Use `chunks()` to collect chunks or `visit()` for bounded-memory processing. To write, construct a `WriteConfig` with `new(format)` or extension-inferred `from_output(path)`, create `ReadStatWriter::new(config, schema)`, call `write(&batch)` for each batch, then consume it with `finish()` to atomically publish the output and obtain the written row count. See the [crate documentation](https://docs.rs/readstat) for complete examples.
 
 ## Features
 
@@ -38,14 +43,15 @@ Output format writers are feature-gated (all enabled by default):
 - `parquet` — Parquet output (Snappy, Zstd, Brotli, Gzip, Lz4 compression)
 - `feather` — Arrow IPC / Feather format
 - `ndjson` — Newline-delimited JSON
-- `sql` — DataFusion SQL query support (optional, not enabled by default)
+- `sql` — DataFusion SQL query support (enabled by default), with synchronous and asynchronous APIs
 
 ## Key Types
 
-- `ReadStatData` — Coordinates FFI parsing, accumulates values directly into typed Arrow builders
+- `ReadStatReader` — Primary path, owned-bytes, and mmap reader; supports row/column selection, metadata, whole reads, chunks, and visitors
 - `ReadStatMetadata` — File-level metadata (row/var counts, encoding, compression, schema)
 - `ReadStatWriter` — Writes Arrow batches to the requested output format
-- `ReadStatPath` — Validated input file path
 - `WriteConfig` — Output configuration (path, format, compression)
+
+Buffered SQL inputs may be executed repeatedly. Use `record_batch_channel` with synchronous APIs and `async_record_batch_channel` with async APIs for bounded, error-aware streaming input. Only channel-backed SQL input is single-execution because its receiver is consumed by the first scan; async output encoding runs off the executor with bounded backpressure.
 
 For the full architecture overview, see [docs/ARCHITECTURE.md](https://github.com/curtisalexander/readstat-rs/blob/main/docs/ARCHITECTURE.md).

--- a/crates/readstat/benches/readstat_benchmarks.rs
+++ b/crates/readstat/benches/readstat_benchmarks.rs
@@ -25,7 +25,10 @@ fn setup_path(filename: &str) -> ReadStatPath {
 // Helper to setup WriteConfig for output
 fn setup_write_config(temp_dir: &TempDir, format: readstat::OutFormat) -> WriteConfig {
     let output_path = temp_dir.path().join(format!("output.{format:?}"));
-    WriteConfig::new(Some(output_path), Some(format), true, None, None).unwrap()
+    WriteConfig::new(format)
+        .output(output_path)
+        .unwrap()
+        .overwrite(true)
 }
 
 /// Benchmark: Read metadata only (no data)
@@ -150,9 +153,9 @@ fn bench_write_csv(c: &mut Criterion) {
     group.bench_function("sequential", |b| {
         b.iter(|| {
             let wc = setup_write_config(&temp_dir, readstat::OutFormat::Csv);
-            let mut wtr = ReadStatWriter::new();
-            wtr.write(black_box(&d), black_box(&wc)).unwrap();
-            wtr.finish(black_box(&d), black_box(&wc)).unwrap();
+            let mut wtr = ReadStatWriter::new(wc, d.schema.clone()).unwrap();
+            wtr.write(black_box(d.batch.as_ref().unwrap())).unwrap();
+            wtr.finish().unwrap();
         });
     });
 
@@ -191,18 +194,16 @@ fn bench_write_parquet_compression(c: &mut Criterion) {
                     let output_path = temp_dir
                         .path()
                         .join(format!("output_{}.parquet", compression.0));
-                    let wc = WriteConfig::new(
-                        Some(output_path),
-                        Some(readstat::OutFormat::Parquet),
-                        true,
-                        *comp,
-                        None,
-                    )
-                    .unwrap();
-
-                    let mut wtr = ReadStatWriter::new();
-                    wtr.write(black_box(&d), black_box(&wc)).unwrap();
-                    wtr.finish(black_box(&d), black_box(&wc)).unwrap();
+                    let mut wc = WriteConfig::new(readstat::OutFormat::Parquet)
+                        .output(output_path)
+                        .unwrap()
+                        .overwrite(true);
+                    if let Some(codec) = *comp {
+                        wc = wc.compression(codec, None).unwrap();
+                    }
+                    let mut wtr = ReadStatWriter::new(wc, d.schema.clone()).unwrap();
+                    wtr.write(black_box(d.batch.as_ref().unwrap())).unwrap();
+                    wtr.finish().unwrap();
                 });
             },
         );
@@ -246,6 +247,7 @@ fn bench_parallel_write_buffer_sizes(c: &mut Criterion) {
                             None,
                             None,
                             buffer_bytes,
+                            true,
                         )
                         .unwrap();
                     }
@@ -285,9 +287,9 @@ fn bench_write_formats(c: &mut Criterion) {
             |b, fmt| {
                 b.iter(|| {
                     let wc = setup_write_config(&temp_dir, *fmt);
-                    let mut wtr = ReadStatWriter::new();
-                    wtr.write(black_box(&d), black_box(&wc)).unwrap();
-                    wtr.finish(black_box(&d), black_box(&wc)).unwrap();
+                    let mut wtr = ReadStatWriter::new(wc, d.schema.clone()).unwrap();
+                    wtr.write(black_box(d.batch.as_ref().unwrap())).unwrap();
+                    wtr.finish().unwrap();
                 });
             },
         );
@@ -320,9 +322,9 @@ fn bench_end_to_end_conversion(c: &mut Criterion) {
 
                 // Write
                 let wc = setup_write_config(&temp_dir, *fmt);
-                let mut wtr = ReadStatWriter::new();
-                wtr.write(black_box(&d), black_box(&wc)).unwrap();
-                wtr.finish(black_box(&d), black_box(&wc)).unwrap();
+                let mut wtr = ReadStatWriter::new(wc, d.schema.clone()).unwrap();
+                wtr.write(black_box(d.batch.as_ref().unwrap())).unwrap();
+                wtr.finish().unwrap();
             });
         });
     }

--- a/crates/readstat/src/api.rs
+++ b/crates/readstat/src/api.rs
@@ -1,24 +1,257 @@
 //! High-level convenience entry points for the common case.
 //!
-//! These free functions wrap the lower-level [`ReadStatPath`] / [`ReadStatMetadata`]
-//! / [`ReadStatData`] pipeline for callers who just want to read a whole file.
-//! For streaming, parallelism, or column filtering, use the types directly —
-//! see the crate-level documentation for examples.
+//! [`ReadStatReader`] is the primary reading API. The free functions are concise
+//! equivalents for reading a path with default settings.
 
-use std::path::Path;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
-use arrow_array::RecordBatch;
+use arrow_array::{RecordBatch, RecordBatchOptions};
 
 use crate::{
-    err::ReadStatError, rs_data::ReadStatData, rs_metadata::ReadStatMetadata, rs_path::ReadStatPath,
+    err::ReadStatError, progress::ProgressCallback, rs_data::ReadStatData,
+    rs_metadata::ReadStatMetadata, rs_path::ReadStatPath,
 };
+
+enum Source {
+    Path(ReadStatPath),
+    Bytes(Arc<[u8]>),
+    #[cfg(not(target_arch = "wasm32"))]
+    Mmap(PathBuf),
+}
+
+struct ReadPlan {
+    metadata: ReadStatMetadata,
+    mapping: Option<std::collections::BTreeMap<i32, i32>>,
+    count: u32,
+}
+
+/// High-level, reusable SAS reader.
+///
+/// Configure row and column selection once, then use [`read`](Self::read),
+/// [`chunks`](Self::chunks), or [`visit`](Self::visit). `visit` holds only the
+/// current chunk and is therefore the bounded-memory option.
+pub struct ReadStatReader {
+    source: Source,
+    offset: u32,
+    limit: Option<u32>,
+    columns: Option<Vec<String>>,
+    chunk_rows: u32,
+    progress: Option<Arc<dyn ProgressCallback>>,
+}
+
+impl ReadStatReader {
+    /// Creates a reader for a filesystem path.
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, ReadStatError> {
+        Ok(Self::new(Source::Path(ReadStatPath::new(path)?)))
+    }
+
+    /// Creates a reader owning an in-memory SAS file.
+    #[must_use]
+    pub fn from_bytes(bytes: impl Into<Arc<[u8]>>) -> Self {
+        Self::new(Source::Bytes(bytes.into()))
+    }
+
+    /// Creates a reader which memory maps `path` for each parse.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_mmap(path: impl Into<PathBuf>) -> Result<Self, ReadStatError> {
+        let path = path.into();
+        let _ = ReadStatPath::new(&path)?;
+        Ok(Self::new(Source::Mmap(path)))
+    }
+
+    fn new(source: Source) -> Self {
+        Self {
+            source,
+            offset: 0,
+            limit: None,
+            columns: None,
+            chunk_rows: 10_000,
+            progress: None,
+        }
+    }
+
+    /// Selects the half-open row range beginning at `offset`, optionally limited
+    /// to `limit` rows. The range is validated against metadata when reading.
+    #[must_use]
+    pub fn rows(mut self, offset: u32, limit: Option<u32>) -> Self {
+        self.offset = offset;
+        self.limit = limit;
+        self
+    }
+
+    /// Selects columns by name, preserving dataset order.
+    ///
+    /// An empty selection deliberately produces a zero-column batch with the
+    /// requested number of rows.
+    #[must_use]
+    pub fn columns(mut self, columns: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.columns = Some(columns.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Sets rows per yielded chunk. Zero is rejected when reading.
+    #[must_use]
+    pub fn chunk_rows(mut self, rows: u32) -> Self {
+        self.chunk_rows = rows;
+        self
+    }
+
+    /// Attaches a progress callback.
+    #[must_use]
+    pub fn progress(mut self, callback: Arc<dyn ProgressCallback>) -> Self {
+        self.progress = Some(callback);
+        self
+    }
+
+    /// Reads metadata transactionally.
+    pub fn metadata(&self) -> Result<ReadStatMetadata, ReadStatError> {
+        let mut md = ReadStatMetadata::new();
+        match &self.source {
+            Source::Path(path) => md.read_metadata(path, false)?,
+            Source::Bytes(bytes) => md.read_metadata_from_bytes(bytes, false)?,
+            #[cfg(not(target_arch = "wasm32"))]
+            Source::Mmap(path) => md.read_metadata_from_mmap(path, false)?,
+        }
+        Ok(md)
+    }
+
+    fn plan(&self) -> Result<ReadPlan, ReadStatError> {
+        if self.chunk_rows == 0 {
+            return Err(ReadStatError::InvalidChunkSize);
+        }
+        let md = self.metadata()?;
+        let total = u32::try_from(md.row_count)?;
+        if self.offset > total {
+            return Err(ReadStatError::InvalidRowRange {
+                offset: self.offset,
+                limit: self.limit,
+                row_count: total,
+            });
+        }
+        let available = total - self.offset;
+        let count = self.limit.unwrap_or(available);
+        if count > available {
+            return Err(ReadStatError::InvalidRowRange {
+                offset: self.offset,
+                limit: self.limit,
+                row_count: total,
+            });
+        }
+        let mapping = md.resolve_selected_columns(self.columns.clone())?;
+        Ok(ReadPlan {
+            metadata: md,
+            mapping,
+            count,
+        })
+    }
+
+    /// Visits each batch without collecting previous chunks.
+    pub fn visit(
+        &self,
+        visitor: impl FnMut(RecordBatch) -> Result<(), ReadStatError>,
+    ) -> Result<(), ReadStatError> {
+        let plan = self.plan()?;
+        self.visit_with_plan(&plan, visitor)
+    }
+
+    fn visit_with_plan(
+        &self,
+        plan: &ReadPlan,
+        mut visitor: impl FnMut(RecordBatch) -> Result<(), ReadStatError>,
+    ) -> Result<(), ReadStatError> {
+        let ReadPlan {
+            metadata: md,
+            mapping,
+            count,
+        } = plan;
+        if let Some(progress) = &self.progress {
+            let label = match &self.source {
+                Source::Path(p) => p.path.to_string_lossy().into_owned(),
+                Source::Bytes(_) => "<bytes>".into(),
+                #[cfg(not(target_arch = "wasm32"))]
+                Source::Mmap(p) => p.to_string_lossy().into_owned(),
+            };
+            progress.parsing_started(&label);
+        }
+        for relative in crate::build_offsets(*count, self.chunk_rows).windows(2) {
+            let start = self
+                .offset
+                .checked_add(relative[0])
+                .ok_or_else(|| ReadStatError::Other("row offset overflow".into()))?;
+            let end = self
+                .offset
+                .checked_add(relative[1])
+                .ok_or_else(|| ReadStatError::Other("row offset overflow".into()))?;
+            let mut data = match &mapping {
+                Some(map) => ReadStatData::new().init_filtered(md.clone(), map, start, end),
+                None => ReadStatData::new().init(md.clone(), start, end),
+            };
+            if let Some(progress) = &self.progress {
+                data = data.set_progress(progress.clone());
+            }
+            match &self.source {
+                Source::Path(path) => data.read_data(path)?,
+                Source::Bytes(bytes) => data.read_data_from_bytes(bytes)?,
+                #[cfg(not(target_arch = "wasm32"))]
+                Source::Mmap(path) => data.read_data_from_mmap(path)?,
+            }
+            visitor(
+                data.batch
+                    .ok_or_else(|| ReadStatError::Other("no record batch was produced".into()))?,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Collects all chunks.
+    pub fn chunks(&self) -> Result<Vec<RecordBatch>, ReadStatError> {
+        let mut batches = Vec::new();
+        self.visit(|batch| {
+            batches.push(batch);
+            Ok(())
+        })?;
+        Ok(batches)
+    }
+
+    /// Reads the selected rows into one batch.
+    pub fn read(&self) -> Result<RecordBatch, ReadStatError> {
+        let plan = self.plan()?;
+        let ReadPlan {
+            metadata: md,
+            mapping,
+            ..
+        } = &plan;
+        let schema = mapping.as_ref().map_or_else(
+            || md.schema.clone(),
+            |m| md.filter_to_selected_columns(m).schema,
+        );
+        let mut batches = Vec::new();
+        self.visit_with_plan(&plan, |batch| {
+            batches.push(batch);
+            Ok(())
+        })?;
+        if batches.is_empty() {
+            return Ok(RecordBatch::new_empty(Arc::new(schema)));
+        }
+        if schema.fields().is_empty() {
+            return RecordBatch::try_new_with_options(
+                Arc::new(schema),
+                Vec::new(),
+                &RecordBatchOptions::new().with_row_count(Some(plan.count as usize)),
+            )
+            .map_err(Into::into);
+        }
+        arrow::compute::concat_batches(&Arc::new(schema), &batches).map_err(Into::into)
+    }
+}
 
 /// Reads file-level and variable metadata from a `.sas7bdat` file without
 /// loading any row data.
 ///
-/// This is the one-call equivalent of constructing a [`ReadStatPath`],
-/// creating a [`ReadStatMetadata`], and calling
-/// [`ReadStatMetadata::read_metadata`].
+/// This delegates to [`ReadStatReader::metadata`].
 ///
 /// ```no_run
 /// # fn main() -> Result<(), readstat::ReadStatError> {
@@ -32,17 +265,13 @@ use crate::{
 ///
 /// Returns [`ReadStatError`] if the path is invalid or FFI parsing fails.
 pub fn read_metadata<P: AsRef<Path>>(path: P) -> Result<ReadStatMetadata, ReadStatError> {
-    let rsp = ReadStatPath::new(path)?;
-    let mut md = ReadStatMetadata::new();
-    md.read_metadata(&rsp, false)?;
-    Ok(md)
+    ReadStatReader::from_path(path)?.metadata()
 }
 
 /// Reads every row of a `.sas7bdat` file into a single Arrow [`RecordBatch`].
 ///
-/// Best for files that fit comfortably in memory. For large files, read in
-/// streaming chunks with [`ReadStatData::init`] and [`build_offsets`](crate::build_offsets)
-/// instead — see the crate-level documentation.
+/// Best for files that fit comfortably in memory. For large files, use
+/// [`ReadStatReader::visit`] to process bounded chunks.
 ///
 /// ```no_run
 /// # fn main() -> Result<(), readstat::ReadStatError> {
@@ -57,14 +286,5 @@ pub fn read_metadata<P: AsRef<Path>>(path: P) -> Result<ReadStatMetadata, ReadSt
 /// Returns [`ReadStatError`] if the path is invalid, FFI parsing fails, or the
 /// row count cannot be represented (i.e. is negative).
 pub fn read_to_batch<P: AsRef<Path>>(path: P) -> Result<RecordBatch, ReadStatError> {
-    let rsp = ReadStatPath::new(path)?;
-    let mut md = ReadStatMetadata::new();
-    md.read_metadata(&rsp, false)?;
-
-    let row_count = u32::try_from(md.row_count)?;
-    let mut d = ReadStatData::new().init(md, 0, row_count);
-    d.read_data(&rsp)?;
-
-    d.batch
-        .ok_or_else(|| ReadStatError::Other("no record batch was produced".to_string()))
+    ReadStatReader::from_path(path)?.read()
 }

--- a/crates/readstat/src/api.rs
+++ b/crates/readstat/src/api.rs
@@ -3,10 +3,10 @@
 //! [`ReadStatReader`] is the primary reading API. The free functions are concise
 //! equivalents for reading a path with default settings.
 
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::Path, sync::Arc};
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::PathBuf;
 
 use arrow_array::{RecordBatch, RecordBatchOptions};
 

--- a/crates/readstat/src/common.rs
+++ b/crates/readstat/src/common.rs
@@ -20,7 +20,8 @@ use std::ffi::CStr;
 /// // Produces pairs: [0,10), [10,20), [20,25)
 /// ```
 pub fn build_offsets(row_count: u32, stream_rows: u32) -> Vec<u32> {
-    let chunks = row_count.div_ceil(stream_rows.max(1));
+    let stream_rows = stream_rows.max(1);
+    let chunks = row_count.div_ceil(stream_rows);
     let mut offsets = Vec::with_capacity(chunks as usize + 1);
 
     for c in 0..chunks {
@@ -89,6 +90,11 @@ mod tests {
         assert_eq!(offsets, vec![0]);
         // No windows produced for zero rows
         assert_eq!(offsets.windows(2).count(), 0);
+    }
+
+    #[test]
+    fn build_offsets_zero_chunk_size_is_one() {
+        assert_eq!(build_offsets(4, 0), vec![0, 1, 2, 3, 4]);
     }
 
     #[test]
@@ -180,7 +186,7 @@ mod tests {
             #[test]
             fn offsets_start_at_zero_end_at_row_count(
                 row_count in 0u32..100_000,
-                stream_rows in 1u32..50_000
+                stream_rows in 0u32..50_000
             ) {
                 let offsets = build_offsets(row_count, stream_rows);
                 prop_assert_eq!(*offsets.first().unwrap(), 0);
@@ -191,11 +197,12 @@ mod tests {
             #[test]
             fn offsets_are_monotonically_increasing(
                 row_count in 1u32..100_000,
-                stream_rows in 1u32..50_000
+                stream_rows in 0u32..50_000
             ) {
                 let offsets = build_offsets(row_count, stream_rows);
                 for pair in offsets.windows(2) {
                     prop_assert!(pair[0] < pair[1], "offsets not strictly increasing: {} >= {}", pair[0], pair[1]);
+                    prop_assert!(pair[1] <= row_count);
                 }
             }
 

--- a/crates/readstat/src/err.rs
+++ b/crates/readstat/src/err.rs
@@ -285,6 +285,33 @@ pub enum ReadStatError {
     #[error("The parent directory of the output path {} does not exist", .0.display())]
     OutputParentMissing(PathBuf),
 
+    /// A reader was configured with a zero chunk size.
+    #[error("chunk size must be greater than zero")]
+    InvalidChunkSize,
+
+    /// A selected row range falls outside the dataset.
+    #[error("invalid row range: offset {offset}, limit {limit:?}, row count {row_count}")]
+    InvalidRowRange {
+        /// First requested row.
+        offset: u32,
+        /// Optional requested row count.
+        limit: Option<u32>,
+        /// Dataset row count.
+        row_count: u32,
+    },
+
+    /// A batch does not have the schema supplied to the writer constructor.
+    #[error("record batch schema does not match writer schema")]
+    SchemaMismatch,
+
+    /// Output destination or format settings are inconsistent.
+    #[error("invalid output configuration: {0}")]
+    InvalidOutputConfig(String),
+
+    /// Compression codec and level settings are inconsistent.
+    #[error("invalid compression configuration: {0}")]
+    InvalidCompressionConfig(String),
+
     /// The format string is not a recognized output format.
     #[error("Unknown format: {0:?}. Expected one of: csv, feather, ndjson, parquet")]
     UnknownFormat(String),
@@ -301,6 +328,13 @@ pub enum ReadStatError {
     #[cfg(feature = "sql")]
     #[error("{0}")]
     DataFusion(#[from] datafusion::error::DataFusionError),
+
+    /// A synchronous SQL API was called from an asynchronous Tokio context.
+    #[cfg(feature = "sql")]
+    #[error(
+        "synchronous SQL APIs cannot run inside a Tokio runtime; use the corresponding *_async API"
+    )]
+    SyncSqlInAsyncRuntime,
 
     /// Catch-all error with a custom message.
     #[error("{0}")]

--- a/crates/readstat/src/lib.rs
+++ b/crates/readstat/src/lib.rs
@@ -27,8 +27,9 @@
 //!
 //! ## Quick start
 //!
-//! The two convenience functions cover the common case — read metadata, or read
-//! every row into a single Arrow [`RecordBatch`](arrow_array::RecordBatch):
+//! [`ReadStatReader`] is the primary API. It reads paths, owned bytes, or memory
+//! maps and supports metadata, row/column selection, collection, and bounded
+//! chunk callbacks. The two free functions are shorthand for path defaults:
 //!
 //! ```no_run
 //! # fn main() -> Result<(), readstat::ReadStatError> {
@@ -41,8 +42,24 @@
 //! # }
 //! ```
 //!
-//! For streaming, parallelism, or column filtering, drop down to the
-//! [`ReadStatMetadata`] / [`ReadStatData`] types as shown below.
+//! For bounded-memory streaming and selection, configure a reader:
+//!
+//! ```no_run
+//! # fn main() -> Result<(), readstat::ReadStatError> {
+//! let reader = readstat::ReadStatReader::from_path("data.sas7bdat")?
+//!     .columns(["name", "age"])
+//!     .rows(100, Some(1_000))
+//!     .chunk_rows(250);
+//! reader.visit(|batch| {
+//!     println!("received {} rows", batch.num_rows());
+//!     Ok(())
+//! })?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The lower-level metadata and data types remain public for compatibility and
+//! specialized integrations, but new callers should start with [`ReadStatReader`].
 //!
 //! ## Inspect file metadata
 //!
@@ -111,39 +128,17 @@
 //! Each chunk is parsed and written incrementally.
 //!
 //! ```no_run
-//! use readstat::{
-//!     ReadStatPath, ReadStatMetadata, ReadStatData, ReadStatWriter,
-//!     WriteConfig, OutFormat, build_offsets,
-//! };
+//! use readstat::{OutFormat, ReadStatReader, ReadStatWriter, WriteConfig};
 //!
 //! # fn main() -> Result<(), readstat::ReadStatError> {
-//! let rsp = ReadStatPath::new("data.sas7bdat")?;
-//! let wc = WriteConfig::new(
-//!     Some("output.parquet".into()),
-//!     Some(OutFormat::Parquet),
-//!     false, // overwrite
-//!     None,  // compression (defaults to Snappy for Parquet)
-//!     None,  // compression_level
-//! )?;
-//!
-//! let mut md = ReadStatMetadata::new();
-//! md.read_metadata(&rsp, false)?;
-//!
-//! // Build chunk offsets: [0, 10000, 20000, ..., row_count]
-//! let offsets = build_offsets(md.row_count as u32, 10_000);
-//! let mut wtr = ReadStatWriter::new();
-//! let pairs = offsets.windows(2);
-//! let pairs_cnt = pairs.len();
-//!
-//! for (i, w) in pairs.enumerate() {
-//!     let mut d = ReadStatData::new().init(md.clone(), w[0], w[1]);
-//!     d.read_data(&rsp)?;
-//!     wtr.write(&d, &wc)?;
-//!     if i == pairs_cnt - 1 {
-//!         let rows = wtr.finish(&d, &wc)?;
-//!         println!("wrote {rows} rows");
-//!     }
-//! }
+//! let reader = ReadStatReader::from_path("data.sas7bdat")?.chunk_rows(10_000);
+//! let schema = std::sync::Arc::new(reader.metadata()?.schema);
+//! let config = WriteConfig::new(OutFormat::Parquet)
+//!     .output("output.parquet")?
+//!     .overwrite(false);
+//! let mut writer = ReadStatWriter::new(config, schema)?;
+//! reader.visit(|batch| writer.write(&batch))?;
+//! println!("wrote {} rows", writer.finish()?);
 //! # Ok(())
 //! # }
 //! ```
@@ -269,7 +264,7 @@
 //! | `parquet` | Parquet | Columnar format via `parquet` crate, 5 compression codecs |
 //! | `feather` | Feather | Arrow IPC format via `arrow-ipc` |
 //! | `ndjson` | NDJSON | Newline-delimited JSON via `arrow-json` |
-//! | `sql` | SQL | Query data with SQL via DataFusion (not enabled by default) |
+//! | `sql` | SQL | Query data with SQL via DataFusion (enabled by default) |
 //!
 //! # Arrow version policy
 //!
@@ -293,14 +288,10 @@
 // Re-export the Arrow ecosystem crates so consumers can name the types that
 // appear in this crate's public API without pinning Arrow themselves. See the
 // "Arrow version policy" section above.
+pub use api::{ReadStatReader, read_metadata, read_to_batch};
 pub use arrow;
 pub use arrow_array;
 pub use arrow_schema;
-// Re-exported so consumers can construct the channels used by the streaming
-// SQL API ([`ChunkReceiver`](crate::ChunkReceiver)).
-pub use crossbeam;
-
-pub use api::{read_metadata, read_to_batch};
 pub use common::build_offsets;
 pub use err::{ReadStatCError, ReadStatError};
 pub use progress::ProgressCallback;
@@ -310,8 +301,10 @@ pub use rs_path::ReadStatPath;
 #[cfg(feature = "sql")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sql")))]
 pub use rs_query::{
-    ChunkReceiver, execute_sql, execute_sql_and_write_stream, execute_sql_stream, read_sql_file,
-    write_sql_results,
+    AsyncRecordBatchReceiver, AsyncRecordBatchSender, RecordBatchReceiver, RecordBatchSender,
+    async_record_batch_channel, execute_sql, execute_sql_and_write_stream,
+    execute_sql_and_write_stream_async, execute_sql_async, execute_sql_stream,
+    execute_sql_stream_async, read_sql_file, record_batch_channel,
 };
 pub use rs_var::{ReadStatVarFormatClass, ReadStatVarType, ReadStatVarTypeClass};
 pub use rs_write::ReadStatWriter;

--- a/crates/readstat/src/rs_data.rs
+++ b/crates/readstat/src/rs_data.rs
@@ -7,7 +7,7 @@
 
 use arrow::datatypes::Schema;
 use arrow_array::{
-    ArrayRef, RecordBatch,
+    ArrayRef, RecordBatch, RecordBatchOptions,
     builder::{
         Date32Builder, Float32Builder, Float64Builder, Int16Builder, Int32Builder, StringBuilder,
         Time32MillisecondBuilder, Time32SecondBuilder, Time64MicrosecondBuilder,
@@ -300,7 +300,15 @@ impl ReadStatData {
             .map(ColumnBuilder::finish)
             .collect();
 
-        self.batch = Some(RecordBatch::try_new(self.schema.clone(), arrays)?);
+        self.batch = Some(if arrays.is_empty() {
+            RecordBatch::try_new_with_options(
+                self.schema.clone(),
+                arrays,
+                &RecordBatchOptions::new().with_row_count(Some(self.chunk_rows_processed)),
+            )?
+        } else {
+            RecordBatch::try_new(self.schema.clone(), arrays)?
+        });
 
         Ok(())
     }
@@ -332,6 +340,7 @@ impl ReadStatData {
         // parse data and if successful then convert cols into a record batch
         self.parse_data(rsp)?;
         self.cols_to_batch()?;
+        self.report_progress();
         Ok(())
     }
 
@@ -346,6 +355,7 @@ impl ReadStatData {
     pub fn read_data_from_bytes(&mut self, bytes: &[u8]) -> Result<(), ReadStatError> {
         self.parse_data_from_bytes(bytes)?;
         self.cols_to_batch()?;
+        self.report_progress();
         Ok(())
     }
 
@@ -400,15 +410,13 @@ impl ReadStatData {
         }
         check_c_error(error as i32)?;
 
-        // Advance the progress bar by the rows just parsed. Doing this *after*
-        // the chunk completes (rather than before) keeps the displayed position
-        // in step with work actually done — under `--parallel` a pre-parse
-        // increment made the bar jump straight to 100%.
-        if let Some(progress) = &self.progress {
-            progress.inc(self.chunk_rows_to_process as u64);
-        }
-
         Ok(())
+    }
+
+    fn report_progress(&self) {
+        if let Some(progress) = &self.progress {
+            progress.inc(self.batch.as_ref().map_or(0, RecordBatch::num_rows) as u64);
+        }
     }
 
     #[allow(clippy::cast_possible_wrap, clippy::ptr_as_ptr)]

--- a/crates/readstat/src/rs_metadata.rs
+++ b/crates/readstat/src/rs_metadata.rs
@@ -67,6 +67,10 @@ impl Default for ReadStatMetadata {
 }
 
 impl ReadStatMetadata {
+    /// Serializes this metadata as pretty-printed JSON.
+    pub fn to_json(&self) -> Result<String, ReadStatError> {
+        Ok(serde_json::to_string_pretty(self)?)
+    }
     /// Creates a new `ReadStatMetadata` with default (empty) values.
     pub fn new() -> Self {
         Self {
@@ -173,10 +177,11 @@ impl ReadStatMetadata {
         rsp: &ReadStatPath,
         skip_row_count: bool,
     ) -> Result<(), ReadStatError> {
+        let mut parsed = Self::new();
         debug!("Path as C string is {:?}", rsp.cstring_path);
         let ppath = rsp.cstring_path.as_ptr();
 
-        let ctx = std::ptr::from_mut::<Self>(self) as *mut c_void;
+        let ctx = std::ptr::from_mut::<Self>(&mut parsed) as *mut c_void;
 
         let error: readstat_sys::readstat_error_t = readstat_sys::readstat_error_e_READSTAT_OK;
         debug!("Initially, error ==> {error}");
@@ -192,7 +197,8 @@ impl ReadStatMetadata {
         check_c_error(error as i32)?;
 
         // if successful, initialize schema
-        self.schema = self.initialize_schema();
+        parsed.schema = parsed.initialize_schema();
+        *self = parsed;
         Ok(())
     }
 
@@ -215,9 +221,10 @@ impl ReadStatMetadata {
         bytes: &[u8],
         skip_row_count: bool,
     ) -> Result<(), ReadStatError> {
+        let mut parsed = Self::new();
         let mut buffer_ctx = ReadStatBufferCtx::new(bytes);
 
-        let ctx = std::ptr::from_mut::<Self>(self) as *mut c_void;
+        let ctx = std::ptr::from_mut::<Self>(&mut parsed) as *mut c_void;
 
         let error: readstat_sys::readstat_error_t = readstat_sys::readstat_error_e_READSTAT_OK;
         debug!("Initially, error ==> {error}");
@@ -239,7 +246,8 @@ impl ReadStatMetadata {
         check_c_error(error as i32)?;
 
         // if successful, initialize schema
-        self.schema = self.initialize_schema();
+        parsed.schema = parsed.initialize_schema();
+        *self = parsed;
         Ok(())
     }
 
@@ -268,25 +276,6 @@ impl ReadStatMetadata {
         let file = File::open(path)?;
         let mmap = unsafe { memmap2::Mmap::map(&file)? };
         self.read_metadata_from_bytes(&mmap, skip_row_count)
-    }
-
-    /// Parses a columns file, returning column names.
-    ///
-    /// Lines starting with `#` are treated as comments and blank lines are skipped.
-    /// Each remaining line is trimmed and used as a column name.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ReadStatError`] if the file cannot be read.
-    pub fn parse_columns_file(path: &Path) -> Result<Vec<String>, ReadStatError> {
-        let contents = std::fs::read_to_string(path)?;
-        let names: Vec<String> = contents
-            .lines()
-            .map(str::trim)
-            .filter(|line| !line.is_empty() && !line.starts_with('#'))
-            .map(std::string::ToString::to_string)
-            .collect();
-        Ok(names)
     }
 
     /// Validates column names against the dataset's variables and returns a mapping
@@ -465,7 +454,6 @@ impl ReadStatVarMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
 
     /// Create a test metadata instance with the given variable names.
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
@@ -761,52 +749,6 @@ mod tests {
         assert_eq!(field_meta.get("storage_width").unwrap(), "8");
         assert!(!field_meta.contains_key("display_width"));
         assert!(schema.metadata().is_empty());
-    }
-
-    // --- parse_columns_file ---
-
-    #[test]
-    fn parse_columns_file_normal() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("cols.txt");
-        let mut f = File::create(&path).unwrap();
-        writeln!(f, "col_a").unwrap();
-        writeln!(f, "col_b").unwrap();
-        writeln!(f, "col_c").unwrap();
-
-        let names = ReadStatMetadata::parse_columns_file(&path).unwrap();
-        assert_eq!(names, vec!["col_a", "col_b", "col_c"]);
-    }
-
-    #[test]
-    fn parse_columns_file_with_comments_and_blanks() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("cols.txt");
-        let mut f = File::create(&path).unwrap();
-        writeln!(f, "# This is a comment").unwrap();
-        writeln!(f, "col_a").unwrap();
-        writeln!(f).unwrap();
-        writeln!(f, "  col_b  ").unwrap();
-        writeln!(f, "# Another comment").unwrap();
-
-        let names = ReadStatMetadata::parse_columns_file(&path).unwrap();
-        assert_eq!(names, vec!["col_a", "col_b"]);
-    }
-
-    #[test]
-    fn parse_columns_file_empty() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("cols.txt");
-        File::create(&path).unwrap();
-
-        let names = ReadStatMetadata::parse_columns_file(&path).unwrap();
-        assert!(names.is_empty());
-    }
-
-    #[test]
-    fn parse_columns_file_nonexistent() {
-        let path = Path::new("/nonexistent/path/cols.txt");
-        assert!(ReadStatMetadata::parse_columns_file(path).is_err());
     }
 
     // --- ReadStatMetadata defaults ---

--- a/crates/readstat/src/rs_metadata.rs
+++ b/crates/readstat/src/rs_metadata.rs
@@ -11,10 +11,11 @@ use num_derive::FromPrimitive;
 use serde::Serialize;
 #[cfg(any(not(target_arch = "wasm32"), test))]
 use std::fs::File;
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::Path;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     ffi::{CString, c_void},
-    path::Path,
 };
 
 use crate::cb::{handle_metadata, handle_variable};

--- a/crates/readstat/src/rs_query.rs
+++ b/crates/readstat/src/rs_query.rs
@@ -1,13 +1,8 @@
 //! SQL query execution via Apache DataFusion.
-//!
-//! Registers Arrow [`RecordBatch`] data as an in-memory table in a DataFusion
-//! [`SessionContext`], executes a SQL query, and returns the results as a
-//! `Vec<RecordBatch>`.
+
+use std::sync::{Arc, Mutex};
 
 use arrow_array::RecordBatch;
-use arrow_csv::WriterBuilder as CsvWriterBuilder;
-use arrow_ipc::writer::FileWriter as IpcFileWriter;
-use arrow_json::LineDelimitedWriter as JsonLineDelimitedWriter;
 use arrow_schema::SchemaRef;
 use datafusion::catalog::streaming::StreamingTable;
 use datafusion::datasource::MemTable;
@@ -16,93 +11,106 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::streaming::PartitionStream;
 use datafusion::prelude::*;
 use futures::StreamExt;
-use parquet::{arrow::ArrowWriter as ParquetArrowWriter, file::properties::WriterProperties};
-use std::io::BufWriter;
-use std::path::Path;
-use std::sync::{Arc, Mutex};
 
-use crate::err::ReadStatError;
-use crate::rs_data::ReadStatData;
-use crate::rs_path::ReadStatPath;
-use crate::rs_write_config::{
-    OutFormat, ParquetCompression, WriteConfig, resolve_parquet_compression,
-};
+use crate::{ReadStatError, ReadStatWriter, WriteConfig};
 
-/// Channel receiver type for streaming parsed data chunks between threads.
-///
-/// Each message contains the parsed [`ReadStatData`], the source [`ReadStatPath`],
-/// and the chunk index. Construct the matching sender/receiver pair with the
-/// re-exported [`crossbeam`](crate::crossbeam) channel functions.
-pub type ChunkReceiver = crossbeam::channel::Receiver<(ReadStatData, ReadStatPath, usize)>;
+/// Error-aware Arrow batch receiver used by streaming SQL queries.
+pub type RecordBatchReceiver = crossbeam::channel::Receiver<Result<RecordBatch, ReadStatError>>;
+/// Sending half of a streaming SQL input channel.
+pub type RecordBatchSender = crossbeam::channel::Sender<Result<RecordBatch, ReadStatError>>;
+/// Async receiving half of a streaming SQL input channel.
+pub type AsyncRecordBatchReceiver = tokio::sync::mpsc::Receiver<Result<RecordBatch, ReadStatError>>;
+/// Async sending half of a streaming SQL input channel.
+pub type AsyncRecordBatchSender = tokio::sync::mpsc::Sender<Result<RecordBatch, ReadStatError>>;
 
-/// Executes a SQL query against in-memory Arrow data.
+/// Creates a bounded input channel for streaming SQL queries.
 ///
-/// Registers the provided batches as a table named `table_name` in a
-/// DataFusion [`SessionContext`], runs the SQL query, and collects the
-/// results.
-///
-/// # Arguments
-///
-/// * `batches` - The data to query, as one or more [`RecordBatch`]es
-/// * `schema` - The Arrow schema shared by all batches
-/// * `table_name` - The name used to reference the table in SQL
-/// * `sql` - The SQL query string to execute
+/// A bounded channel applies backpressure to producers; capacity zero creates
+/// a rendezvous channel.
+#[must_use]
+pub fn record_batch_channel(capacity: usize) -> (RecordBatchSender, RecordBatchReceiver) {
+    crossbeam::channel::bounded(capacity)
+}
+
+/// Creates a bounded, executor-friendly input channel for async SQL queries.
 ///
 /// # Errors
 ///
-/// Returns [`ReadStatError`] if the Tokio runtime cannot be created, the table
-/// cannot be registered, or the query fails to plan or execute.
+/// Returns an error when `capacity` is zero.
+pub fn async_record_batch_channel(
+    capacity: usize,
+) -> Result<(AsyncRecordBatchSender, AsyncRecordBatchReceiver), ReadStatError> {
+    if capacity == 0 {
+        return Err(ReadStatError::Other(
+            "async record batch channel capacity must be greater than zero".into(),
+        ));
+    }
+    Ok(tokio::sync::mpsc::channel(capacity))
+}
+
+fn runtime() -> Result<tokio::runtime::Runtime, ReadStatError> {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return Err(ReadStatError::SyncSqlInAsyncRuntime);
+    }
+    Ok(tokio::runtime::Runtime::new()?)
+}
+
+/// Synchronously executes SQL against in-memory Arrow batches.
 pub fn execute_sql(
     batches: Vec<RecordBatch>,
     schema: SchemaRef,
     table_name: &str,
     sql: &str,
 ) -> Result<Vec<RecordBatch>, ReadStatError> {
-    let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(execute_sql_async(batches, schema, table_name, sql))
+    runtime()?.block_on(execute_sql_async(batches, schema, table_name, sql))
 }
 
-async fn execute_sql_async(
+/// Executes SQL asynchronously against in-memory Arrow batches.
+pub async fn execute_sql_async(
     batches: Vec<RecordBatch>,
     schema: SchemaRef,
     table_name: &str,
     sql: &str,
 ) -> Result<Vec<RecordBatch>, ReadStatError> {
     let ctx = SessionContext::new();
-
-    let table = MemTable::try_new(schema, vec![batches])?;
-    ctx.register_table(table_name, Arc::new(table))?;
-
-    let df = ctx.sql(sql).await?;
-    let result_schema = Arc::new(df.schema().as_arrow().clone());
-    let results = df.collect().await?;
-
-    // A query may legitimately return zero rows (e.g. `WHERE 1=0`). Return a
-    // single empty batch carrying the result schema so downstream writers can
-    // still produce a valid (header-only) output file.
-    if results.is_empty() {
-        return Ok(vec![RecordBatch::new_empty(result_schema)]);
-    }
-
-    Ok(results)
+    ctx.register_table(
+        table_name,
+        Arc::new(MemTable::try_new(schema, vec![batches])?),
+    )?;
+    collect_with_empty_batch(ctx.sql(sql).await?).await
 }
 
-/// A [`PartitionStream`] implementation that reads `RecordBatch`es from a
-/// crossbeam channel, allowing DataFusion to consume data as it arrives
-/// without collecting everything into memory first.
+async fn collect_with_empty_batch(df: DataFrame) -> Result<Vec<RecordBatch>, ReadStatError> {
+    let schema = Arc::new(df.schema().as_arrow().clone());
+    let results = df.collect().await?;
+    Ok(if results.is_empty() {
+        vec![RecordBatch::new_empty(schema)]
+    } else {
+        results
+    })
+}
+
+/// A channel-backed partition is single-execution because receiving consumes
+/// its input. Plans that scan it more than once return an execution error.
 #[derive(Debug)]
 struct ChannelPartitionStream {
     schema: SchemaRef,
-    receiver: Arc<Mutex<Option<ChunkReceiver>>>,
+    receiver: Arc<Mutex<Option<InputReceiver>>>,
 }
 
 impl ChannelPartitionStream {
-    fn new(schema: SchemaRef, receiver: ChunkReceiver) -> Self {
+    fn new(schema: SchemaRef, receiver: InputReceiver) -> Self {
         Self {
             schema,
             receiver: Arc::new(Mutex::new(Some(receiver))),
         }
     }
+}
+
+#[derive(Debug)]
+enum InputReceiver {
+    Blocking(RecordBatchReceiver),
+    Async(AsyncRecordBatchReceiver),
 }
 
 impl PartitionStream for ChannelPartitionStream {
@@ -111,244 +119,274 @@ impl PartitionStream for ChannelPartitionStream {
     }
 
     fn execute(&self, _ctx: Arc<datafusion::execution::TaskContext>) -> SendableRecordBatchStream {
-        // The receiver is moved out on first execute, so this partition can be
-        // consumed exactly once. Some query plans (notably self-joins) execute a
-        // partition more than once; rather than panic inside the execution
-        // operator — which would abort the whole process — surface a recoverable
-        // query error so the caller gets an `Err` from the query instead.
-        let Some(receiver) = self
+        let receiver = self
             .receiver
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .take()
-        else {
-            let err = datafusion::error::DataFusionError::Execution(
-                "ChannelPartitionStream can only be executed once; this query plan reads the \
-                 streaming input more than once (e.g. a self-join). Re-run with the \
-                 non-streaming SQL path (execute_sql), which buffers the data."
-                    .to_string(),
-            );
-            let stream = futures::stream::once(async move { Err(err) });
-            return Box::pin(RecordBatchStreamAdapter::new(self.schema.clone(), stream));
+            .take();
+        let schema = self.schema.clone();
+        let stream = match receiver {
+            Some(receiver) => {
+                let receiver = match receiver {
+                    InputReceiver::Async(receiver) => receiver,
+                    InputReceiver::Blocking(receiver) => {
+                        let (sender, receiver_async) = tokio::sync::mpsc::channel(2);
+                        // Crossbeam receive is blocking. Bridge it from a dedicated
+                        // thread so polling DataFusion never blocks a Tokio worker.
+                        std::thread::spawn(move || {
+                            loop {
+                                if sender.is_closed() {
+                                    break;
+                                }
+                                match receiver
+                                    .recv_timeout(std::time::Duration::from_millis(100))
+                                {
+                                    Ok(result) => {
+                                        if sender.blocking_send(result).is_err() {
+                                            break;
+                                        }
+                                    }
+                                    Err(crossbeam::channel::RecvTimeoutError::Timeout) => {}
+                                    Err(crossbeam::channel::RecvTimeoutError::Disconnected) => break,
+                                }
+                            }
+                        });
+                        receiver_async
+                    }
+                };
+                futures::stream::unfold(receiver, |mut receiver| async move {
+                    receiver.recv().await.map(|batch| {
+                        let batch = batch.map_err(|error| {
+                            datafusion::error::DataFusionError::External(Box::new(error))
+                        });
+                        (batch, receiver)
+                    })
+                })
+                .left_stream()
+            }
+            None => futures::stream::once(async {
+                Err(datafusion::error::DataFusionError::Execution(
+                    "channel-backed StreamingTable can only be executed once; use execute_sql for plans that scan input multiple times".into(),
+                ))
+            })
+            .right_stream(),
         };
-
-        let stream =
-            futures::stream::iter(receiver.into_iter().filter_map(|(d, _, _)| d.batch).map(Ok));
-
-        Box::pin(RecordBatchStreamAdapter::new(self.schema.clone(), stream))
+        Box::pin(RecordBatchStreamAdapter::new(schema, stream))
     }
 }
 
-/// Executes a SQL query by streaming data from a crossbeam channel through
-/// DataFusion, avoiding double-materialization of the full dataset.
-///
-/// The receiver is consumed directly by DataFusion's query engine via
-/// [`StreamingTable`], and results are collected via `execute_stream()`.
-///
-/// # Single-execution limit
-///
-/// The streaming input is consumed exactly once. Query plans that read the
-/// table more than once (e.g. a self-join on the streamed table) will fail with
-/// a DataFusion execution error. Use [`execute_sql`] (which buffers the data)
-/// for such queries.
-///
-/// # Errors
-///
-/// Returns [`ReadStatError`] if the Tokio runtime cannot be created, the table
-/// cannot be registered, or the query fails to plan or execute.
-pub fn execute_sql_stream(
-    receiver: ChunkReceiver,
+fn streaming_context(
+    receiver: InputReceiver,
     schema: SchemaRef,
     table_name: &str,
-    sql: &str,
-) -> Result<Vec<RecordBatch>, ReadStatError> {
-    let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(execute_sql_stream_async(receiver, schema, table_name, sql))
-}
-
-async fn execute_sql_stream_async(
-    receiver: ChunkReceiver,
-    schema: SchemaRef,
-    table_name: &str,
-    sql: &str,
-) -> Result<Vec<RecordBatch>, ReadStatError> {
+) -> Result<SessionContext, ReadStatError> {
     let ctx = SessionContext::new();
-
     let partition = ChannelPartitionStream::new(schema.clone(), receiver);
-    let table = StreamingTable::try_new(schema, vec![Arc::new(partition)])?;
-    ctx.register_table(table_name, Arc::new(table))?;
-
-    let df = ctx.sql(sql).await?;
-    let mut stream = df.execute_stream().await?;
-
-    let mut results = Vec::new();
-    while let Some(batch) = stream.next().await {
-        results.push(batch?);
-    }
-
-    Ok(results)
+    ctx.register_table(
+        table_name,
+        Arc::new(StreamingTable::try_new(schema, vec![Arc::new(partition)])?),
+    )?;
+    Ok(ctx)
 }
 
-/// Executes a SQL query by streaming data from a crossbeam channel and writes
-/// the results directly to an output file, avoiding intermediate collection.
+/// Synchronously executes SQL from a single-use channel of Arrow batches.
 ///
-/// This combines [`execute_sql_stream`] and [`write_sql_results`] into one
-/// streaming pass for the Data command path.
-///
-/// The output path in `write_config` must be `Some`; returns an error otherwise.
-/// A query that returns zero rows still produces a valid output file
-/// (header-only CSV, empty Parquet/Feather/NDJSON) carrying the result schema.
-///
-/// # Single-execution limit
-///
-/// As with [`execute_sql_stream`], the streaming input is consumed exactly once;
-/// query plans that read the table more than once (e.g. a self-join) fail with a
-/// DataFusion execution error. Use the non-streaming path for those.
-///
-/// # Errors
-///
-/// Returns [`ReadStatError`] if the output path is missing, the Tokio runtime
-/// cannot be created, the query fails, or writing the results fails.
-pub fn execute_sql_and_write_stream(
-    receiver: ChunkReceiver,
+/// Input is consumed incrementally; query results are collected in memory.
+pub fn execute_sql_stream(
+    receiver: RecordBatchReceiver,
     schema: SchemaRef,
     table_name: &str,
     sql: &str,
-    write_config: &WriteConfig,
-) -> Result<(), ReadStatError> {
-    let rt = tokio::runtime::Runtime::new()?;
-    rt.block_on(execute_sql_and_write_stream_async(
-        receiver,
+) -> Result<Vec<RecordBatch>, ReadStatError> {
+    runtime()?.block_on(execute_sql_from_input_async(
+        InputReceiver::Blocking(receiver),
         schema,
         table_name,
         sql,
-        write_config,
     ))
 }
 
-async fn execute_sql_and_write_stream_async(
-    receiver: ChunkReceiver,
+/// Asynchronously executes SQL from a single-use channel of Arrow batches.
+///
+/// Input is consumed incrementally without blocking the async executor; query
+/// results are collected in memory. Plans that scan the input more than once
+/// are unsupported.
+pub async fn execute_sql_stream_async(
+    receiver: AsyncRecordBatchReceiver,
     schema: SchemaRef,
     table_name: &str,
     sql: &str,
-    write_config: &WriteConfig,
-) -> Result<(), ReadStatError> {
-    let output_path = write_config
-        .out_path
-        .as_deref()
-        .ok_or_else(|| ReadStatError::Other("Output path is required for SQL write".into()))?;
+) -> Result<Vec<RecordBatch>, ReadStatError> {
+    execute_sql_from_input_async(InputReceiver::Async(receiver), schema, table_name, sql).await
+}
 
-    let ctx = SessionContext::new();
+async fn execute_sql_from_input_async(
+    receiver: InputReceiver,
+    schema: SchemaRef,
+    table_name: &str,
+    sql: &str,
+) -> Result<Vec<RecordBatch>, ReadStatError> {
+    let ctx = streaming_context(receiver, schema, table_name)?;
+    collect_with_empty_batch(ctx.sql(sql).await?).await
+}
 
-    let partition = ChannelPartitionStream::new(schema.clone(), receiver);
-    let table = StreamingTable::try_new(schema, vec![Arc::new(partition)])?;
-    ctx.register_table(table_name, Arc::new(table))?;
+/// Synchronously streams SQL output directly to a configured writer.
+pub fn execute_sql_and_write_stream(
+    receiver: RecordBatchReceiver,
+    schema: SchemaRef,
+    table_name: &str,
+    sql: &str,
+    config: &WriteConfig,
+) -> Result<usize, ReadStatError> {
+    runtime()?.block_on(execute_sql_and_write_from_input_async(
+        InputReceiver::Blocking(receiver),
+        schema,
+        table_name,
+        sql,
+        config,
+    ))
+}
 
+/// Asynchronously writes each SQL output batch as soon as DataFusion produces it.
+/// Plans that scan the channel-backed table more than once are unsupported.
+pub async fn execute_sql_and_write_stream_async(
+    receiver: AsyncRecordBatchReceiver,
+    schema: SchemaRef,
+    table_name: &str,
+    sql: &str,
+    config: &WriteConfig,
+) -> Result<usize, ReadStatError> {
+    execute_sql_and_write_from_input_async(
+        InputReceiver::Async(receiver),
+        schema,
+        table_name,
+        sql,
+        config,
+    )
+    .await
+}
+
+async fn execute_sql_and_write_from_input_async(
+    receiver: InputReceiver,
+    schema: SchemaRef,
+    table_name: &str,
+    sql: &str,
+    config: &WriteConfig,
+) -> Result<usize, ReadStatError> {
+    let ctx = streaming_context(receiver, schema, table_name)?;
     let df = ctx.sql(sql).await?;
     let result_schema = Arc::new(df.schema().as_arrow().clone());
     let mut stream = df.execute_stream().await?;
-
-    // Collect all result batches — we need the output schema (which may differ
-    // from the input schema due to projections/aggregations) before we can open
-    // a writer, and some formats (Feather/IPC) need all data before finishing.
-    let mut result_batches: Vec<RecordBatch> = Vec::new();
+    enum Message {
+        Batch(RecordBatch),
+        Finish,
+    }
+    let (sender, mut receiver) = tokio::sync::mpsc::channel(2);
+    let config = config.clone();
+    let writer_task = tokio::task::spawn_blocking(move || {
+        let mut writer = ReadStatWriter::new(config, result_schema)?;
+        while let Some(message) = receiver.blocking_recv() {
+            match message {
+                Message::Batch(batch) => writer.write(&batch)?,
+                Message::Finish => return writer.finish(),
+            }
+        }
+        Err(ReadStatError::Other(
+            "SQL output was cancelled before the writer finished".into(),
+        ))
+    });
     while let Some(batch) = stream.next().await {
-        result_batches.push(batch?);
+        sender
+            .send(Message::Batch(batch?))
+            .await
+            .map_err(|_| ReadStatError::Other("SQL writer stopped unexpectedly".into()))?;
     }
-
-    // A query may legitimately return zero rows. Synthesize a single empty
-    // batch carrying the result schema so a valid (header-only/empty) output
-    // file is still produced — matching the buffered `execute_sql` path.
-    if result_batches.is_empty() {
-        result_batches.push(RecordBatch::new_empty(result_schema));
-    }
-
-    write_sql_results(
-        &result_batches,
-        output_path,
-        write_config.format,
-        write_config.compression,
-        write_config.compression_level,
-    )?;
-
-    Ok(())
+    sender
+        .send(Message::Finish)
+        .await
+        .map_err(|_| ReadStatError::Other("SQL writer stopped unexpectedly".into()))?;
+    drop(sender);
+    writer_task
+        .await
+        .map_err(|error| ReadStatError::Other(format!("SQL writer task failed: {error}")))?
 }
 
-/// Writes SQL result batches to an output file in the specified format.
-///
-/// Returns `Ok(())` without writing anything if `batches` is empty.
-///
-/// # Errors
-///
-/// Returns [`ReadStatError`] if the output file cannot be created or a write
-/// fails for the chosen format.
-pub fn write_sql_results(
-    batches: &[RecordBatch],
-    output_path: &Path,
-    format: OutFormat,
-    compression: Option<ParquetCompression>,
-    compression_level: Option<u32>,
-) -> Result<(), ReadStatError> {
-    if batches.is_empty() {
-        return Ok(());
-    }
-    let schema = batches[0].schema();
-
-    match format {
-        OutFormat::Csv => {
-            let f = std::fs::File::create(output_path)?;
-            let mut writer = CsvWriterBuilder::new()
-                .with_header(true)
-                .build(BufWriter::new(f));
-            for batch in batches {
-                writer.write(batch)?;
-            }
-        }
-        OutFormat::Feather => {
-            let f = std::fs::File::create(output_path)?;
-            let mut writer = IpcFileWriter::try_new(BufWriter::new(f), &schema)?;
-            for batch in batches {
-                writer.write(batch)?;
-            }
-            writer.finish()?;
-        }
-        OutFormat::Ndjson => {
-            let f = std::fs::File::create(output_path)?;
-            let mut writer = JsonLineDelimitedWriter::new(BufWriter::new(f));
-            for batch in batches {
-                writer.write(batch)?;
-            }
-            writer.finish()?;
-        }
-        OutFormat::Parquet => {
-            let f = std::fs::File::create(output_path)?;
-            let codec = resolve_parquet_compression(compression, compression_level)?;
-            let props = WriterProperties::builder()
-                .set_compression(codec)
-                .set_statistics_enabled(parquet::file::properties::EnabledStatistics::Page)
-                .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_2_0)
-                .build();
-            let mut writer = ParquetArrowWriter::try_new(BufWriter::new(f), schema, Some(props))?;
-            for batch in batches {
-                writer.write(batch)?;
-            }
-            writer.close()?;
-        }
-    }
-    Ok(())
-}
-
-/// Reads a SQL query from a file path.
-///
-/// # Errors
-///
-/// Returns [`ReadStatError`] if the file cannot be read or contains only
-/// whitespace.
+/// Reads and validates a SQL query file.
 pub fn read_sql_file(path: &std::path::Path) -> Result<String, ReadStatError> {
-    let sql = std::fs::read_to_string(path)?;
-    let sql = sql.trim().to_string();
+    let sql = std::fs::read_to_string(path)?.trim().to_string();
     if sql.is_empty() {
         return Err(ReadStatError::EmptySqlFile(path.to_path_buf()));
     }
     Ok(sql)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{Int32Array, RecordBatch};
+    use arrow_schema::{DataType, Field, Schema};
+
+    fn input() -> (SchemaRef, RecordBatch) {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int32,
+            false,
+        )]));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1, 2]))])
+                .unwrap();
+        (schema, batch)
+    }
+
+    #[tokio::test]
+    async fn async_query_and_sync_runtime_guard() {
+        let (schema, batch) = input();
+        let result = execute_sql_async(vec![batch.clone()], schema.clone(), "t", "select * from t")
+            .await
+            .unwrap();
+        assert_eq!(result.iter().map(RecordBatch::num_rows).sum::<usize>(), 2);
+        assert!(matches!(
+            execute_sql(vec![batch], schema, "t", "select * from t"),
+            Err(ReadStatError::SyncSqlInAsyncRuntime)
+        ));
+    }
+
+    #[tokio::test]
+    async fn streaming_propagates_channel_errors_and_preserves_empty_schema() {
+        let (schema, batch) = input();
+        let (sender, receiver) = async_record_batch_channel(1).unwrap();
+        sender
+            .send(Err(ReadStatError::Other("source failed".into())))
+            .await
+            .unwrap();
+        drop(sender);
+        let error = execute_sql_stream_async(receiver, schema.clone(), "t", "select * from t")
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("source failed"));
+
+        let (sender, receiver) = async_record_batch_channel(1).unwrap();
+        sender.send(Ok(batch)).await.unwrap();
+        drop(sender);
+        let result = execute_sql_stream_async(receiver, schema, "t", "select * from t where 1=0")
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].num_rows(), 0);
+        assert_eq!(result[0].num_columns(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn streaming_does_not_block_current_thread_runtime() {
+        let (schema, batch) = input();
+        let (sender, receiver) = async_record_batch_channel(1).unwrap();
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            sender.send(Ok(batch)).await.unwrap();
+        });
+        let result = execute_sql_stream_async(receiver, schema, "t", "select * from t")
+            .await
+            .unwrap();
+        assert_eq!(result.iter().map(RecordBatch::num_rows).sum::<usize>(), 2);
+    }
 }

--- a/crates/readstat/src/rs_write.rs
+++ b/crates/readstat/src/rs_write.rs
@@ -5,7 +5,6 @@
 //! streaming writes across multiple batches. It also supports metadata output
 //! (pretty-printed or JSON) and parallel Parquet writes via temporary files.
 
-#[cfg(feature = "parquet")]
 use arrow_array::RecordBatch;
 #[cfg(feature = "csv")]
 use arrow_csv::WriterBuilder as CsvWriterBuilder;
@@ -15,6 +14,7 @@ use arrow_ipc::writer::FileWriter as IpcFileWriter;
 use arrow_json::LineDelimitedWriter as JsonLineDelimitedWriter;
 #[cfg(feature = "parquet")]
 use arrow_schema::Schema;
+use arrow_schema::SchemaRef;
 #[cfg(feature = "parquet")]
 use parquet::{
     arrow::ArrowWriter as ParquetArrowWriter, basic::Compression as ParquetCompressionCodec,
@@ -28,7 +28,7 @@ use std::fs;
     feature = "ndjson",
     feature = "parquet"
 ))]
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 #[cfg(any(
     feature = "csv",
     feature = "feather",
@@ -53,9 +53,6 @@ use std::sync::Arc;
 use tempfile::SpooledTempFile;
 
 use crate::err::ReadStatError;
-use crate::rs_data::ReadStatData;
-use crate::rs_metadata::ReadStatMetadata;
-use crate::rs_path::ReadStatPath;
 #[cfg(any(
     feature = "csv",
     feature = "feather",
@@ -66,6 +63,18 @@ use crate::rs_write_config::OutFormat;
 #[cfg(feature = "parquet")]
 use crate::rs_write_config::ParquetCompression;
 use crate::rs_write_config::WriteConfig;
+
+#[cfg(feature = "parquet")]
+struct StagingGuard(Option<PathBuf>);
+
+#[cfg(feature = "parquet")]
+impl Drop for StagingGuard {
+    fn drop(&mut self) {
+        if let Some(path) = self.0.take() {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
 
 /// Internal wrapper around the Parquet Arrow writer, allowing ownership transfer on close.
 #[cfg(feature = "parquet")]
@@ -104,7 +113,6 @@ pub(crate) enum ReadStatWriterFormat {
 /// Supports streaming writes across multiple batches. The writer is created lazily
 /// on the first call to [`write`](ReadStatWriter::write) and finalized via
 /// [`finish`](ReadStatWriter::finish).
-#[derive(Default)]
 // With no format features enabled the fields are written but never read.
 #[cfg_attr(
     not(any(
@@ -122,36 +130,52 @@ pub struct ReadStatWriter {
     pub(crate) wrote_header: bool,
     /// Whether any data has been written (controls file creation vs. append).
     pub(crate) wrote_start: bool,
-}
-
-impl ReadStatWriter {
-    /// Creates a new `ReadStatWriter` with no active writer.
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {
-            wtr: None,
-            wrote_header: false,
-            wrote_start: false,
-        }
-    }
-
-    /// Opens (creating or truncating) the output file. Called exactly once per
-    /// output — every caller guards with `!self.wrote_start` and keeps the
-    /// returned writer open for subsequent batches.
+    config: WriteConfig,
+    schema: SchemaRef,
+    rows_written: usize,
     #[cfg(any(
         feature = "csv",
         feature = "feather",
         feature = "ndjson",
         feature = "parquet"
     ))]
-    fn open_output(&self, path: &Path) -> Result<File, ReadStatError> {
+    staging_path: Option<PathBuf>,
+}
+
+impl ReadStatWriter {
+    /// Creates a new `ReadStatWriter` with no active writer.
+    pub fn new(config: WriteConfig, schema: SchemaRef) -> Result<Self, ReadStatError> {
+        config.validate()?;
+        Ok(Self {
+            wtr: None,
+            wrote_header: false,
+            wrote_start: false,
+            config,
+            schema,
+            rows_written: 0,
+            #[cfg(any(
+                feature = "csv",
+                feature = "feather",
+                feature = "ndjson",
+                feature = "parquet"
+            ))]
+            staging_path: None,
+        })
+    }
+
+    /// Opens a sibling staging file. Called exactly once per output; successful
+    /// finalization publishes it to the configured destination.
+    #[cfg(any(
+        feature = "csv",
+        feature = "feather",
+        feature = "ndjson",
+        feature = "parquet"
+    ))]
+    fn open_output(&mut self, wc: &WriteConfig) -> Result<File, ReadStatError> {
         debug_assert!(!self.wrote_start, "output file opened twice");
-        let f = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(path)?;
-        Ok(f)
+        let (file, staging_path) = crate::rs_write_config::open_output(wc)?;
+        self.staging_path = Some(staging_path);
+        Ok(file)
     }
 
     /// Write a single batch to a Parquet file (for parallel writes).
@@ -170,6 +194,7 @@ impl ReadStatWriter {
         compression: Option<ParquetCompression>,
         compression_level: Option<u32>,
         buffer_size_bytes: usize,
+        overwrite: bool,
     ) -> Result<(), ReadStatError> {
         // Create a SpooledTempFile that keeps data in memory until buffer_size_bytes
         let mut spooled_file = SpooledTempFile::new(buffer_size_bytes);
@@ -189,14 +214,22 @@ impl ReadStatWriter {
         wtr.write(batch)?;
         wtr.close()?;
 
-        // Now copy from SpooledTempFile to the actual output file
+        // Copy into a sibling staging file and publish only after the complete
+        // Parquet payload has been copied successfully.
         spooled_file.seek(SeekFrom::Start(0))?;
-        let mut output_file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(output_path)?;
-        std::io::copy(&mut spooled_file, &mut output_file)?;
+        let (mut output_file, staging_path) =
+            crate::rs_write_config::create_staging_file(output_path)?;
+        let mut staging = StagingGuard(Some(staging_path));
+        if let Err(error) = std::io::copy(&mut spooled_file, &mut output_file) {
+            return Err(error.into());
+        }
+        drop(output_file);
+        crate::rs_write_config::publish_staging(
+            staging.0.as_deref().expect("staging is armed"),
+            output_path,
+            overwrite,
+        )?;
+        staging.0 = None;
 
         Ok(())
     }
@@ -215,14 +248,12 @@ impl ReadStatWriter {
         schema: &Schema,
         compression: Option<ParquetCompression>,
         compression_level: Option<u32>,
+        overwrite: bool,
     ) -> Result<(), ReadStatError> {
         use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
-        let f = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(output_path)?;
+        let (f, staging_path) = crate::rs_write_config::create_staging_file(output_path)?;
+        let mut staging = StagingGuard(Some(staging_path));
 
         let compression_codec = Self::resolve_compression(compression, compression_level)?;
 
@@ -244,12 +275,20 @@ impl ReadStatWriter {
             for batch in reader {
                 writer.write(&batch?)?;
             }
-
-            // Clean up temp file
-            fs::remove_file(temp_file)?;
         }
 
-        writer.close()?;
+        if let Err(error) = writer.close() {
+            return Err(error.into());
+        }
+        crate::rs_write_config::publish_staging(
+            staging.0.as_deref().expect("staging is armed"),
+            output_path,
+            overwrite,
+        )?;
+        staging.0 = None;
+        for temp_file in temp_files {
+            fs::remove_file(temp_file)?;
+        }
         Ok(())
     }
 
@@ -263,46 +302,76 @@ impl ReadStatWriter {
 
     /// Finalizes the writer, flushing and closing the underlying format writer.
     ///
-    /// Returns the total number of rows written, as tracked by the shared
-    /// counter on `d`. The library does not print anything — the caller (e.g.
-    /// the CLI) is responsible for any user-facing summary output.
+    /// Returns the total number of successfully written rows. Consuming the
+    /// writer makes finalization a one-shot operation. The library does not
+    /// print anything; callers own user-facing summary output.
     ///
     /// # Errors
     ///
     /// Returns an error if the underlying writer fails to flush or close,
     /// or if the output format is not enabled.
     #[allow(unused_variables)]
-    pub fn finish(&mut self, d: &ReadStatData, wc: &WriteConfig) -> Result<usize, ReadStatError> {
-        match wc.format {
+    pub fn finish(mut self) -> Result<usize, ReadStatError> {
+        // Initialize even for zero rows, producing a schema-carrying output.
+        if !self.wrote_start {
+            self.write(&RecordBatch::new_empty(self.schema.clone()))?;
+        }
+        match self.config.format {
             #[cfg(feature = "csv")]
             OutFormat::Csv => {
                 // Explicitly flush: relying on BufWriter's Drop would silently
                 // discard I/O errors (e.g. disk full), reporting success over
                 // a truncated file.
                 self.flush_buffered()?;
-                Ok(rows_written(d))
+                self.publish()
             }
             #[cfg(feature = "feather")]
             OutFormat::Feather => {
                 self.finish_feather()?;
-                Ok(rows_written(d))
+                self.publish()
             }
             #[cfg(feature = "ndjson")]
             OutFormat::Ndjson => {
                 self.flush_buffered()?;
-                Ok(rows_written(d))
+                self.publish()
             }
             #[cfg(feature = "parquet")]
             OutFormat::Parquet => {
                 self.finish_parquet()?;
-                Ok(rows_written(d))
+                self.publish()
             }
             #[allow(unreachable_patterns)]
             _ => Err(ReadStatError::Other(format!(
                 "Output format {:?} is not enabled. Enable the corresponding feature flag.",
-                wc.format
+                self.config.format
             ))),
         }
+    }
+
+    #[cfg(any(
+        feature = "csv",
+        feature = "feather",
+        feature = "ndjson",
+        feature = "parquet"
+    ))]
+    fn publish(&mut self) -> Result<usize, ReadStatError> {
+        let Some(staging) = self.staging_path.take() else {
+            return Ok(self.rows_written);
+        };
+        // Close every handle before publication (required by Windows too).
+        self.wtr = None;
+        let destination = self
+            .config
+            .out_path
+            .as_ref()
+            .expect("staging has destination");
+        let result =
+            crate::rs_write_config::publish_staging(&staging, destination, self.config.overwrite);
+        if result.is_err() {
+            let _ = std::fs::remove_file(&staging);
+        }
+        result?;
+        Ok(self.rows_written)
     }
 
     /// Flushes the buffered file writer for formats (CSV, NDJSON) whose
@@ -359,58 +428,65 @@ impl ReadStatWriter {
     /// Returns an error if the output file cannot be opened, writing fails,
     /// or the output format is not enabled.
     #[allow(unused_variables)]
-    pub fn write(&mut self, d: &ReadStatData, wc: &WriteConfig) -> Result<(), ReadStatError> {
+    pub fn write(&mut self, batch: &RecordBatch) -> Result<(), ReadStatError> {
+        if batch.schema() != self.schema {
+            return Err(ReadStatError::SchemaMismatch);
+        }
+        let wc = self.config.clone();
         match wc.format {
             #[cfg(feature = "csv")]
             OutFormat::Csv => {
                 if wc.out_path.is_none() {
                     if self.wrote_header {
-                        self.write_data_to_stdout(d)
+                        self.write_data_to_stdout(batch)
                     } else {
-                        self.write_header_to_stdout(d)?;
-                        self.write_data_to_stdout(d)
+                        self.write_header_to_stdout()?;
+                        self.write_data_to_stdout(batch)
                     }
                 } else {
-                    self.write_data_to_csv(d, wc)
+                    self.write_data_to_csv(batch, &wc)
                 }
             }
             #[cfg(feature = "feather")]
-            OutFormat::Feather => self.write_data_to_feather(d, wc),
+            OutFormat::Feather => self.write_data_to_feather(batch, &wc),
             #[cfg(feature = "ndjson")]
-            OutFormat::Ndjson => self.write_data_to_ndjson(d, wc),
+            OutFormat::Ndjson => self.write_data_to_ndjson(batch, &wc),
             #[cfg(feature = "parquet")]
-            OutFormat::Parquet => self.write_data_to_parquet(d, wc),
+            OutFormat::Parquet => self.write_data_to_parquet(batch, &wc),
             #[allow(unreachable_patterns)]
             _ => Err(ReadStatError::Other(format!(
                 "Output format {:?} is not enabled. Enable the corresponding feature flag.",
                 wc.format
             ))),
-        }
+        }?;
+        self.rows_written = self
+            .rows_written
+            .checked_add(batch.num_rows())
+            .ok_or_else(|| ReadStatError::Other("writer row count overflow".into()))?;
+        Ok(())
     }
 
     #[cfg(feature = "csv")]
     fn write_data_to_csv(
         &mut self,
-        d: &ReadStatData,
+        batch: &RecordBatch,
         wc: &WriteConfig,
     ) -> Result<(), ReadStatError> {
-        if let Some(p) = &wc.out_path {
+        if wc.out_path.is_some() {
             // Open the file only on the first batch; later batches reuse the
             // open writer. Opening (and immediately dropping) the handle on
             // every batch was wasted syscalls.
             if !self.wrote_start {
-                let f = self.open_output(p)?;
+                let f = self.open_output(wc)?;
                 self.wtr = Some(ReadStatWriterFormat::Csv(BufWriter::new(f)));
             }
 
             // write
             if let Some(ReadStatWriterFormat::Csv(f)) = &mut self.wtr {
-                if let Some(batch) = &d.batch {
-                    let include_header = !self.wrote_header;
-                    let mut writer = CsvWriterBuilder::new().with_header(include_header).build(f);
-                    writer.write(batch)?;
-                    self.wrote_header = true;
-                }
+                let include_header = !self.wrote_header;
+                let mut writer = CsvWriterBuilder::new().with_header(include_header).build(f);
+                writer.write(batch)?;
+                self.wrote_header = true;
 
                 self.wrote_start = true;
                 Ok(())
@@ -429,22 +505,20 @@ impl ReadStatWriter {
     #[cfg(feature = "feather")]
     fn write_data_to_feather(
         &mut self,
-        d: &ReadStatData,
+        batch: &RecordBatch,
         wc: &WriteConfig,
     ) -> Result<(), ReadStatError> {
-        if let Some(p) = &wc.out_path {
+        if wc.out_path.is_some() {
             // Open the file only on the first batch (see write_data_to_csv).
             if !self.wrote_start {
-                let f = self.open_output(p)?;
-                let wtr = IpcFileWriter::try_new(BufWriter::new(f), &d.schema)?;
+                let f = self.open_output(wc)?;
+                let wtr = IpcFileWriter::try_new(BufWriter::new(f), &self.schema)?;
                 self.wtr = Some(ReadStatWriterFormat::Feather(wtr));
             }
 
             // write
             if let Some(ReadStatWriterFormat::Feather(wtr)) = &mut self.wtr {
-                if let Some(batch) = &d.batch {
-                    wtr.write(batch)?;
-                }
+                wtr.write(batch)?;
 
                 self.wrote_start = true;
 
@@ -465,23 +539,21 @@ impl ReadStatWriter {
     #[cfg(feature = "ndjson")]
     fn write_data_to_ndjson(
         &mut self,
-        d: &ReadStatData,
+        batch: &RecordBatch,
         wc: &WriteConfig,
     ) -> Result<(), ReadStatError> {
-        if let Some(p) = &wc.out_path {
+        if wc.out_path.is_some() {
             // Open the file only on the first batch (see write_data_to_csv).
             if !self.wrote_start {
-                let f = self.open_output(p)?;
+                let f = self.open_output(wc)?;
                 self.wtr = Some(ReadStatWriterFormat::Ndjson(BufWriter::new(f)));
             }
 
             // write
             if let Some(ReadStatWriterFormat::Ndjson(f)) = &mut self.wtr {
-                if let Some(batch) = &d.batch {
-                    let mut writer = JsonLineDelimitedWriter::new(f);
-                    writer.write(batch)?;
-                    writer.finish()?;
-                }
+                let mut writer = JsonLineDelimitedWriter::new(f);
+                writer.write(batch)?;
+                writer.finish()?;
 
                 self.wrote_start = true;
 
@@ -502,14 +574,14 @@ impl ReadStatWriter {
     #[cfg(feature = "parquet")]
     fn write_data_to_parquet(
         &mut self,
-        d: &ReadStatData,
+        batch: &RecordBatch,
         wc: &WriteConfig,
     ) -> Result<(), ReadStatError> {
-        if let Some(p) = &wc.out_path {
+        if wc.out_path.is_some() {
             // setup writer — open the file only on the first batch (see
             // write_data_to_csv).
             if !self.wrote_start {
-                let f = self.open_output(p)?;
+                let f = self.open_output(wc)?;
                 let compression_codec =
                     Self::resolve_compression(wc.compression, wc.compression_level)?;
 
@@ -519,8 +591,11 @@ impl ReadStatWriter {
                     .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_2_0)
                     .build();
 
-                let wtr =
-                    ParquetArrowWriter::try_new(BufWriter::new(f), d.schema.clone(), Some(props))?;
+                let wtr = ParquetArrowWriter::try_new(
+                    BufWriter::new(f),
+                    self.schema.clone(),
+                    Some(props),
+                )?;
 
                 self.wtr = Some(ReadStatWriterFormat::Parquet(ReadStatParquetWriter::new(
                     wtr,
@@ -529,9 +604,7 @@ impl ReadStatWriter {
 
             // write
             if let Some(ReadStatWriterFormat::Parquet(pwtr)) = &mut self.wtr {
-                if let Some(batch) = &d.batch
-                    && let Some(ref mut wtr) = pwtr.wtr
-                {
+                if let Some(ref mut wtr) = pwtr.wtr {
                     wtr.write(batch)?;
                 }
 
@@ -552,7 +625,7 @@ impl ReadStatWriter {
     }
 
     #[cfg(feature = "csv")]
-    fn write_data_to_stdout(&mut self, d: &ReadStatData) -> Result<(), ReadStatError> {
+    fn write_data_to_stdout(&mut self, batch: &RecordBatch) -> Result<(), ReadStatError> {
         // writer setup
         if !self.wrote_start {
             self.wtr = Some(ReadStatWriterFormat::CsvStdout(stdout()));
@@ -560,10 +633,8 @@ impl ReadStatWriter {
 
         // write
         if let Some(ReadStatWriterFormat::CsvStdout(f)) = &mut self.wtr {
-            if let Some(batch) = &d.batch {
-                let mut writer = CsvWriterBuilder::new().with_header(false).build(f);
-                writer.write(batch)?;
-            }
+            let mut writer = CsvWriterBuilder::new().with_header(false).build(f);
+            writer.write(batch)?;
 
             self.wrote_start = true;
 
@@ -576,16 +647,17 @@ impl ReadStatWriter {
     }
 
     #[cfg(feature = "csv")]
-    fn write_header_to_stdout(&mut self, d: &ReadStatData) -> Result<(), ReadStatError> {
+    fn write_header_to_stdout(&mut self) -> Result<(), ReadStatError> {
         use std::io::Write;
 
         // CSV-escape each name so the header stays well-formed and column-aligned
         // with the (already-escaped) data rows. Variable names may legally contain
         // commas or quotes under SAS `VALIDVARNAME=ANY`.
-        let header = d
-            .vars
-            .values()
-            .map(|m| csv_escape_field(&m.var_name))
+        let header = self
+            .schema
+            .fields()
+            .iter()
+            .map(|field| csv_escape_field(field.name()))
             .collect::<Vec<_>>()
             .join(",");
 
@@ -597,102 +669,22 @@ impl ReadStatWriter {
 
         Ok(())
     }
-
-    /// Formats file and variable metadata for display, as either pretty text
-    /// (when `as_json` is false) or pretty-printed JSON.
-    ///
-    /// The library does not print — the caller is responsible for emitting the
-    /// returned string.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if JSON serialization fails.
-    pub fn metadata_to_string(
-        md: &ReadStatMetadata,
-        rsp: &ReadStatPath,
-        as_json: bool,
-    ) -> Result<String, ReadStatError> {
-        if as_json {
-            Self::metadata_to_json(md)
-        } else {
-            Ok(Self::format_metadata(md, rsp))
-        }
-    }
-
-    /// Serializes metadata as pretty-printed JSON.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if JSON serialization fails.
-    pub fn metadata_to_json(md: &ReadStatMetadata) -> Result<String, ReadStatError> {
-        Ok(serde_json::to_string_pretty(md)?)
-    }
-
-    /// Formats metadata as a human-readable, multi-line string.
-    #[must_use]
-    #[allow(clippy::cast_sign_loss)]
-    pub fn format_metadata(md: &ReadStatMetadata, rsp: &ReadStatPath) -> String {
-        use crate::rs_var::ReadStatVarFormatClass;
-        use std::fmt::Write as _;
-
-        let mut out = String::new();
-        // Writing to a String is infallible; the `let _ =` discards the Result.
-        let _ = writeln!(
-            out,
-            "Metadata for the file {}\n",
-            rsp.path.to_string_lossy()
-        );
-        let _ = writeln!(out, "Row count: {}", md.row_count);
-        let _ = writeln!(out, "Variable count: {}", md.var_count);
-        let _ = writeln!(out, "Table name: {}", md.table_name);
-        let _ = writeln!(out, "Table label: {}", md.file_label);
-        let _ = writeln!(out, "File encoding: {}", md.file_encoding);
-        let _ = writeln!(out, "Format version: {}", md.version);
-        let _ = writeln!(
-            out,
-            "Bitness: {}",
-            if md.is_64bit { "64-bit" } else { "32-bit" }
-        );
-        let _ = writeln!(out, "Creation time: {}", md.creation_time);
-        let _ = writeln!(out, "Modified time: {}", md.modified_time);
-        let _ = writeln!(out, "Compression: {:#?}", md.compression);
-        let _ = writeln!(out, "Byte order: {:#?}", md.endianness);
-        let _ = writeln!(out, "Variable names:");
-        for (k, v) in &md.vars {
-            let format_class = v.var_format_class.as_ref().map_or("", |f| match f {
-                ReadStatVarFormatClass::Date => "Date",
-                ReadStatVarFormatClass::DateTime
-                | ReadStatVarFormatClass::DateTimeWithMilliseconds
-                | ReadStatVarFormatClass::DateTimeWithMicroseconds
-                | ReadStatVarFormatClass::DateTimeWithNanoseconds => "DateTime",
-                ReadStatVarFormatClass::Time
-                | ReadStatVarFormatClass::TimeWithMilliseconds
-                | ReadStatVarFormatClass::TimeWithMicroseconds
-                | ReadStatVarFormatClass::TimeWithNanoseconds => "Time",
-            });
-            let data_type = md.schema.fields[*k as usize].data_type();
-            let _ = writeln!(
-                out,
-                "{k}: {} {{ type class: {:#?}, type: {:#?}, label: {}, format class: {format_class}, format: {}, arrow data type: {data_type:#?} }}",
-                v.var_name, v.var_type_class, v.var_type, v.var_label, v.var_format,
-            );
-        }
-
-        out
-    }
 }
 
-/// Total rows written so far, as tracked by the shared row counter on `d`.
-#[cfg(any(
-    feature = "csv",
-    feature = "feather",
-    feature = "ndjson",
-    feature = "parquet"
-))]
-fn rows_written(d: &ReadStatData) -> usize {
-    d.total_rows_processed
-        .as_ref()
-        .map_or(0, |trp| trp.load(std::sync::atomic::Ordering::SeqCst))
+impl Drop for ReadStatWriter {
+    fn drop(&mut self) {
+        #[cfg(any(
+            feature = "csv",
+            feature = "feather",
+            feature = "ndjson",
+            feature = "parquet"
+        ))]
+        if let Some(path) = self.staging_path.take() {
+            // Drop format writers/file handles before attempting cleanup.
+            self.wtr = None;
+            let _ = std::fs::remove_file(path);
+        }
+    }
 }
 
 /// Escapes a single CSV field per RFC 4180: if it contains a comma, double
@@ -851,10 +843,137 @@ mod tests {
 
     #[test]
     fn new_writer_defaults() {
-        let wtr = ReadStatWriter::new();
+        let wtr = ReadStatWriter::new(WriteConfig::new(OutFormat::Csv), Arc::new(Schema::empty()))
+            .unwrap();
         assert!(wtr.wtr.is_none());
         assert!(!wtr.wrote_header);
         assert!(!wtr.wrote_start);
+    }
+
+    fn test_batch(schema: SchemaRef, values: &[&str]) -> RecordBatch {
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(arrow_array::StringArray::from(values.to_vec()))],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn multi_batch_rows_and_consuming_finish() {
+        let dir = tempfile::tempdir().unwrap();
+        let schema = Arc::new(Schema::new(vec![arrow_schema::Field::new(
+            "x",
+            arrow_schema::DataType::Utf8,
+            false,
+        )]));
+        let config = WriteConfig::new(OutFormat::Csv)
+            .output(dir.path().join("rows.csv"))
+            .unwrap();
+        let mut writer = ReadStatWriter::new(config, schema.clone()).unwrap();
+        writer
+            .write(&test_batch(schema.clone(), &["a", "b"]))
+            .unwrap();
+        writer.write(&test_batch(schema.clone(), &["c"])).unwrap();
+        assert_eq!(writer.finish().unwrap(), 3);
+    }
+
+    #[test]
+    fn rejects_schema_mismatch() {
+        let schema = Arc::new(Schema::empty());
+        let mut writer = ReadStatWriter::new(WriteConfig::new(OutFormat::Csv), schema).unwrap();
+        let other = Arc::new(Schema::new(vec![arrow_schema::Field::new(
+            "x",
+            arrow_schema::DataType::Utf8,
+            true,
+        )]));
+        assert!(matches!(
+            writer.write(&RecordBatch::new_empty(other)),
+            Err(ReadStatError::SchemaMismatch)
+        ));
+    }
+
+    #[test]
+    fn empty_output_for_each_enabled_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let schema = Arc::new(Schema::empty());
+        let formats = [
+            OutFormat::Csv,
+            OutFormat::Feather,
+            OutFormat::Ndjson,
+            OutFormat::Parquet,
+        ];
+        for format in formats {
+            let path = dir.path().join(format!("empty.{format}"));
+            let config = WriteConfig::new(format).output(&path).unwrap();
+            let writer = ReadStatWriter::new(config, schema.clone()).unwrap();
+            assert_eq!(writer.finish().unwrap(), 0);
+            assert!(path.exists());
+        }
+    }
+
+    #[test]
+    fn output_open_race_and_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("race.csv");
+        let config = WriteConfig::new(OutFormat::Csv).output(&path).unwrap();
+        std::fs::write(&path, "sentinel").unwrap();
+        let schema = Arc::new(Schema::empty());
+        let writer = ReadStatWriter::new(config, schema.clone()).unwrap();
+        assert!(matches!(
+            writer.finish(),
+            Err(ReadStatError::OutputFileExists(_))
+        ));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "sentinel");
+
+        let config = WriteConfig::new(OutFormat::Csv)
+            .output(&path)
+            .unwrap()
+            .overwrite(true);
+        let writer = ReadStatWriter::new(config, schema).unwrap();
+        writer.finish().unwrap();
+        assert_ne!(std::fs::read_to_string(path).unwrap(), "sentinel");
+    }
+
+    #[test]
+    fn drop_before_finish_preserves_destination_and_cleans_staging() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("preserve.csv");
+        std::fs::write(&path, "sentinel").unwrap();
+        let schema = Arc::new(Schema::new(vec![arrow_schema::Field::new(
+            "x",
+            arrow_schema::DataType::Utf8,
+            false,
+        )]));
+        let config = WriteConfig::new(OutFormat::Csv)
+            .output(&path)
+            .unwrap()
+            .overwrite(true);
+        let mut writer = ReadStatWriter::new(config, schema.clone()).unwrap();
+        writer.write(&test_batch(schema, &["new"])).unwrap();
+        drop(writer);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "sentinel");
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn no_overwrite_destination_raced_before_publication() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("raced.csv");
+        let schema = Arc::new(Schema::new(vec![arrow_schema::Field::new(
+            "x",
+            arrow_schema::DataType::Utf8,
+            false,
+        )]));
+        let config = WriteConfig::new(OutFormat::Csv).output(&path).unwrap();
+        let mut writer = ReadStatWriter::new(config, schema.clone()).unwrap();
+        writer.write(&test_batch(schema, &["new"])).unwrap();
+        std::fs::write(&path, "racer").unwrap();
+        assert!(matches!(
+            writer.finish(),
+            Err(ReadStatError::OutputFileExists(_))
+        ));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "racer");
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
     }
 
     // --- csv_escape_field ---

--- a/crates/readstat/src/rs_write.rs
+++ b/crates/readstat/src/rs_write.rs
@@ -763,7 +763,16 @@ pub fn write_batch_to_feather_bytes(
     Ok(buf)
 }
 
-#[cfg(test)]
+// These lifecycle tests exercise every writer backend together. Keep the
+// module aligned with that contract so minimal-feature test builds remain a
+// valid supported configuration.
+#[cfg(all(
+    test,
+    feature = "csv",
+    feature = "feather",
+    feature = "ndjson",
+    feature = "parquet"
+))]
 mod tests {
     use super::*;
 

--- a/crates/readstat/src/rs_write_config.rs
+++ b/crates/readstat/src/rs_write_config.rs
@@ -8,8 +8,6 @@ use std::path::{Path, PathBuf};
 #[cfg(feature = "parquet")]
 use parquet::basic::{BrotliLevel, Compression as ParquetCompressionCodec, GzipLevel, ZstdLevel};
 
-use log::warn;
-
 use crate::err::ReadStatError;
 
 /// Output file format for data conversion.
@@ -130,7 +128,7 @@ impl std::str::FromStr for ParquetCompression {
 /// behavior. Created separately from [`ReadStatPath`](crate::ReadStatPath),
 /// which handles only input path validation.
 ///
-/// Fields are private and validated by [`new`](WriteConfig::new); read them via
+/// Fields are private and validated by the builder methods; read them via
 /// the accessor methods. This prevents constructing a config that bypasses path,
 /// extension, and compression-level validation.
 #[derive(Debug, Clone)]
@@ -148,44 +146,86 @@ pub struct WriteConfig {
 }
 
 impl WriteConfig {
-    /// Creates a new `WriteConfig` after validating the output path, format,
-    /// and compression settings.
+    /// Infers the format from an output path and returns a validated config.
     ///
     /// # Errors
     ///
-    /// Returns [`ReadStatError`] if the output path, format, or compression settings
-    /// are invalid.
-    pub fn new(
-        out_path: Option<PathBuf>,
-        format: Option<OutFormat>,
-        overwrite: bool,
-        compression: Option<ParquetCompression>,
-        compression_level: Option<u32>,
-    ) -> Result<Self, ReadStatError> {
-        let f = Self::validate_format(format);
-        let op = Self::validate_out_path(out_path, overwrite)?;
-        let op = if let Some(op) = op {
-            Self::validate_out_extension(&op, f)?
-        } else {
-            None
-        };
-        let cl = match compression {
-            None => {
-                if compression_level.is_some() {
-                    warn!("Ignoring value of --compression-level as --compression was not set");
-                }
-                None
+    /// Returns [`ReadStatError`] if the path has an unknown extension or fails
+    /// normal output-path validation.
+    pub fn from_output(path: impl Into<PathBuf>) -> Result<Self, ReadStatError> {
+        let path = path.into();
+        let format = match path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("csv") => OutFormat::Csv,
+            Some("feather") => OutFormat::Feather,
+            Some("ndjson") => OutFormat::Ndjson,
+            Some("parquet") => OutFormat::Parquet,
+            _ => {
+                return Err(ReadStatError::InvalidOutputConfig(format!(
+                    "cannot infer output format from '{}'; supported extensions are .csv, .feather, .ndjson, and .parquet",
+                    path.display()
+                )));
             }
-            Some(pc) => Self::validate_compression_level(pc, compression_level)?,
         };
+        Self::new(format).output(path)
+    }
 
-        Ok(Self {
-            out_path: op,
-            format: f,
-            overwrite,
-            compression,
-            compression_level: cl,
-        })
+    /// Starts a validated configuration for `format`. CSV defaults to stdout;
+    /// other formats require [`output`](Self::output) before writer creation.
+    #[must_use]
+    pub const fn new(format: OutFormat) -> Self {
+        Self {
+            out_path: None,
+            format,
+            overwrite: false,
+            compression: None,
+            compression_level: None,
+        }
+    }
+
+    /// Sets and validates the output path.
+    pub fn output(mut self, path: impl Into<PathBuf>) -> Result<Self, ReadStatError> {
+        let path = Self::validate_out_path(Some(path.into()))?.expect("path was supplied");
+        self.out_path = Self::validate_out_extension(&path, self.format)?;
+        Ok(self)
+    }
+
+    /// Controls atomic publication when the writer is successfully finished.
+    /// When false, publication fails rather than replacing a destination that
+    /// appeared while the output was being written.
+    #[must_use]
+    pub const fn overwrite(mut self, overwrite: bool) -> Self {
+        self.overwrite = overwrite;
+        self
+    }
+
+    /// Sets and validates Parquet compression.
+    pub fn compression(
+        mut self,
+        codec: ParquetCompression,
+        level: Option<u32>,
+    ) -> Result<Self, ReadStatError> {
+        if !matches!(self.format, OutFormat::Parquet) {
+            return Err(ReadStatError::InvalidCompressionConfig(
+                "compression is only supported for Parquet".into(),
+            ));
+        }
+        self.compression_level = Self::validate_compression_level(codec, level)?;
+        self.compression = Some(codec);
+        Ok(self)
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), ReadStatError> {
+        if self.out_path.is_none() && !matches!(self.format, OutFormat::Csv) {
+            return Err(ReadStatError::InvalidOutputConfig(
+                "only CSV may be written to stdout".into(),
+            ));
+        }
+        Ok(())
     }
 
     /// The validated output path, or `None` to write CSV to stdout.
@@ -202,13 +242,13 @@ impl WriteConfig {
 
     /// Whether an existing output file may be overwritten.
     #[must_use]
-    pub const fn overwrite(&self) -> bool {
+    pub const fn is_overwrite(&self) -> bool {
         self.overwrite
     }
 
     /// The configured Parquet compression codec, if any.
     #[must_use]
-    pub const fn compression(&self) -> Option<ParquetCompression> {
+    pub const fn compression_codec(&self) -> Option<ParquetCompression> {
         self.compression
     }
 
@@ -216,10 +256,6 @@ impl WriteConfig {
     #[must_use]
     pub const fn compression_level(&self) -> Option<u32> {
         self.compression_level
-    }
-
-    fn validate_format(format: Option<OutFormat>) -> OutFormat {
-        format.unwrap_or(OutFormat::Csv)
     }
 
     /// Validates the output file extension matches the format.
@@ -237,10 +273,7 @@ impl WriteConfig {
     }
 
     /// Validates the output path exists and handles overwrite logic.
-    fn validate_out_path(
-        path: Option<PathBuf>,
-        overwrite: bool,
-    ) -> Result<Option<PathBuf>, ReadStatError> {
+    fn validate_out_path(path: Option<PathBuf>) -> Result<Option<PathBuf>, ReadStatError> {
         match path {
             None => Ok(None),
             Some(p) => {
@@ -251,19 +284,7 @@ impl WriteConfig {
                     None => Err(ReadStatError::OutputParentMissing(abs_path.clone())),
                     Some(parent) => {
                         if parent.exists() {
-                            if abs_path.exists() {
-                                if overwrite {
-                                    warn!(
-                                        "The file {} will be overwritten!",
-                                        abs_path.to_string_lossy()
-                                    );
-                                    Ok(Some(abs_path))
-                                } else {
-                                    Err(ReadStatError::OutputFileExists(abs_path))
-                                }
-                            } else {
-                                Ok(Some(abs_path))
-                            }
+                            Ok(Some(abs_path))
                         } else {
                             Err(ReadStatError::OutputParentMissing(parent.to_path_buf()))
                         }
@@ -289,12 +310,9 @@ impl WriteConfig {
 
         match (max_level, compression_level) {
             (None | Some(_), None) => Ok(None),
-            (None, Some(_)) => {
-                warn!(
-                    "Compression level is not required for compression={name}, ignoring value of --compression-level"
-                );
-                Ok(None)
-            }
+            (None, Some(_)) => Err(ReadStatError::Other(format!(
+                "compression codec {name} does not support a level"
+            ))),
             (Some(max), Some(c)) => {
                 if c <= max {
                     Ok(Some(c))
@@ -306,6 +324,119 @@ impl WriteConfig {
                 }
             }
         }
+    }
+}
+
+/// Creates a uniquely named staging file beside the destination. Keeping the
+/// staging file in the same directory makes the eventual rename a same-filesystem
+/// operation.
+#[cfg(any(
+    feature = "csv",
+    feature = "feather",
+    feature = "ndjson",
+    feature = "parquet"
+))]
+pub(crate) fn open_output(config: &WriteConfig) -> Result<(std::fs::File, PathBuf), ReadStatError> {
+    create_staging_file(
+        config
+            .out_path
+            .as_ref()
+            .ok_or_else(|| ReadStatError::Other("stdout has no output file".into()))?,
+    )
+}
+
+#[cfg(any(
+    feature = "csv",
+    feature = "feather",
+    feature = "ndjson",
+    feature = "parquet"
+))]
+pub(crate) fn create_staging_file(path: &Path) -> Result<(std::fs::File, PathBuf), ReadStatError> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_STAGING_ID: AtomicU64 = AtomicU64::new(0);
+    let parent = path.parent().expect("validated output has a parent");
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("output");
+    for _ in 0..100 {
+        let id = NEXT_STAGING_ID.fetch_add(1, Ordering::Relaxed);
+        let staging = parent.join(format!(".{name}.readstat-{}-{id}.tmp", std::process::id()));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&staging)
+        {
+            Ok(file) => return Ok((file, staging)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Err(ReadStatError::Other(format!(
+        "could not create a unique staging file for {}",
+        path.display()
+    )))
+}
+
+#[cfg(any(
+    feature = "csv",
+    feature = "feather",
+    feature = "ndjson",
+    feature = "parquet"
+))]
+pub(crate) fn publish_staging(
+    staging: &Path,
+    destination: &Path,
+    overwrite: bool,
+) -> Result<(), ReadStatError> {
+    if overwrite {
+        #[cfg(windows)]
+        {
+            use std::os::windows::ffi::OsStrExt;
+            use windows_sys::Win32::Storage::FileSystem::{
+                MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+            };
+
+            let staging = staging
+                .as_os_str()
+                .encode_wide()
+                .chain(std::iter::once(0))
+                .collect::<Vec<_>>();
+            let destination = destination
+                .as_os_str()
+                .encode_wide()
+                .chain(std::iter::once(0))
+                .collect::<Vec<_>>();
+            // SAFETY: both buffers are NUL-terminated and remain alive for the
+            // duration of the call. Same-directory staging keeps this on one volume.
+            let moved = unsafe {
+                MoveFileExW(
+                    staging.as_ptr(),
+                    destination.as_ptr(),
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+                )
+            };
+            if moved == 0 {
+                Err(std::io::Error::last_os_error().into())
+            } else {
+                Ok(())
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            std::fs::rename(staging, destination).map_err(Into::into)
+        }
+    } else {
+        std::fs::hard_link(staging, destination).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::AlreadyExists {
+                ReadStatError::OutputFileExists(destination.to_owned())
+            } else {
+                error.into()
+            }
+        })?;
+        std::fs::remove_file(staging)?;
+        Ok(())
     }
 }
 
@@ -360,18 +491,15 @@ pub fn resolve_parquet_compression(
 mod tests {
     use super::*;
 
-    // --- validate_format ---
-
     #[test]
-    fn format_none_defaults_to_csv() {
-        let f = WriteConfig::validate_format(None);
-        assert!(matches!(f, OutFormat::Csv));
+    fn from_output_infers_format_case_insensitively() {
+        let config = WriteConfig::from_output("result.PARQUET").unwrap();
+        assert!(matches!(config.format(), OutFormat::Parquet));
     }
 
     #[test]
-    fn format_some_passes_through() {
-        let f = WriteConfig::validate_format(Some(OutFormat::Parquet));
-        assert!(matches!(f, OutFormat::Parquet));
+    fn from_output_rejects_unknown_extension() {
+        assert!(WriteConfig::from_output("result.unknown").is_err());
     }
 
     // --- validate_out_extension ---
@@ -419,25 +547,22 @@ mod tests {
     // --- validate_compression_level ---
 
     #[test]
-    fn uncompressed_ignores_level() {
+    fn uncompressed_rejects_level() {
         let result =
-            WriteConfig::validate_compression_level(ParquetCompression::Uncompressed, Some(5))
-                .unwrap();
-        assert_eq!(result, None);
+            WriteConfig::validate_compression_level(ParquetCompression::Uncompressed, Some(5));
+        assert!(result.is_err());
     }
 
     #[test]
-    fn snappy_ignores_level() {
-        let result =
-            WriteConfig::validate_compression_level(ParquetCompression::Snappy, Some(5)).unwrap();
-        assert_eq!(result, None);
+    fn snappy_rejects_level() {
+        let result = WriteConfig::validate_compression_level(ParquetCompression::Snappy, Some(5));
+        assert!(result.is_err());
     }
 
     #[test]
-    fn lz4raw_ignores_level() {
-        let result =
-            WriteConfig::validate_compression_level(ParquetCompression::Lz4Raw, Some(5)).unwrap();
-        assert_eq!(result, None);
+    fn lz4raw_rejects_level() {
+        let result = WriteConfig::validate_compression_level(ParquetCompression::Lz4Raw, Some(5));
+        assert!(result.is_err());
     }
 
     #[test]
@@ -500,10 +625,6 @@ mod tests {
 
     #[test]
     fn validate_out_path_none() {
-        assert!(
-            WriteConfig::validate_out_path(None, false)
-                .unwrap()
-                .is_none()
-        );
+        assert!(WriteConfig::validate_out_path(None).unwrap().is_none());
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -19,9 +19,10 @@ confidence-threshold = 0.8
 allow = [
     "MIT",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "ISC",
+    "bzip2-1.0.6",
     "Zlib",
     "Unicode-3.0",
     "MPL-2.0",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,13 +32,13 @@ readstat-rs/
 
 ## Crate Details
 
-### `readstat` (v0.25.1) — Library Crate
+### `readstat` (v0.26.0) — Library Crate
 **Path**: `crates/readstat/`
 
 Pure library for parsing SAS binary files into Arrow RecordBatch format.
 Output format writers (CSV, Feather, NDJSON, Parquet) are feature-gated.
 
-Features: `csv`, `feather`, `ndjson`, `parquet` (all enabled by default), `sql`.
+Features: `csv`, `feather`, `ndjson`, `parquet`, and `sql` (all enabled by default).
 
 Key source modules in `crates/readstat/src/`:
 | Module | Purpose |
@@ -60,25 +60,26 @@ Key source modules in `crates/readstat/src/`:
 | `rs_buffer_io.rs` | Buffer I/O operations |
 
 Key public types:
-- `ReadStatData` — coordinates FFI parsing, accumulates values directly into typed Arrow builders, produces Arrow RecordBatch. Internally it uses `ColumnBuilder` (a `pub(crate)` enum wrapping 12 typed Arrow builders — `StringBuilder`, `Float64Builder`, `Date32Builder`, etc.) to append values during FFI callbacks with zero intermediate allocation.
+- `ReadStatReader` — primary reusable reader over a path, owned bytes, or mmap; builder options select rows, columns, and chunk size, and `metadata`, `read`, `chunks`, and `visit` choose materialization strategy.
+- `ReadStatData` — internal parsing engine that accumulates values directly into typed Arrow builders.
 - `ReadStatMetadata` — file-level metadata (row/var counts, encoding, compression, schema)
-- `ReadStatWriter` — writes output in requested format
-- `ReadStatPath` — validated input file path
-- `WriteConfig` — output configuration (path, format, compression)
+- `WriteConfig` — validated builder for output path/format/compression
+- `ReadStatWriter` — initialized with `(config, schema)`, accepts `RecordBatch` values through `write`, and returns the row count from `finish`
 - `OutFormat` — output format enum (Csv, Feather, Ndjson, Parquet)
 - `ProgressCallback` — trait for receiving progress updates during parsing
 
 Major dependencies: Arrow v58 ecosystem, Parquet (5 compression codecs, optional), Rayon, chrono, memmap2.
 
-### `readstat-cli` (v0.25.1) — CLI Binary
+### `readstat-cli` (v0.26.0) — CLI Binary
 **Path**: `crates/readstat-cli/`
 
 Binary crate producing the `readstat` CLI tool. Uses clap with three subcommands:
 - `metadata` — print file metadata (row/var counts, labels, encoding, etc.)
 - `preview` — preview first N rows
-- `data` — convert to output format (csv, feather, ndjson, parquet)
+- `convert` — convert to CSV, Feather, NDJSON, or Parquet; output extension drives format selection
 
 Owns CLI arg parsing, progress bars, colored output, and reader-writer thread orchestration.
+Human metadata formatting and `--columns-file` parsing intentionally live here rather than in the library.
 
 Additional dependencies: clap v4, colored, indicatif, crossbeam, env_logger, path_abs.
 
@@ -150,4 +151,5 @@ Test data lives in `tests/data/*.sas7bdat` (16 datasets). Scripts to regenerate 
 - **Column filtering**: optional `--columns` / `--columns-file` flags restrict parsing to selected variables; unselected values are skipped in the `handle_value` callback while row-boundary detection uses the original (unfiltered) variable count
 - **Arrow pipeline**: SAS data → typed Arrow builders (direct append in FFI callbacks) → Arrow RecordBatch → output format
 - **Multiple I/O strategies**: file path (default), memory-mapped files (`memmap2`), and in-memory byte slices — all feed into the same FFI parsing pipeline
+- **SQL**: DataFusion support is default and exposes sync and async APIs. Buffered input supports repeated scans; only channel-backed streaming input is limited to one execution.
 - **Metadata preservation**: SAS variable labels, format strings, and storage widths are persisted as Arrow field metadata, surviving round-trips through Parquet and Feather. See [TECHNICAL.md](TECHNICAL.md#column-metadata-in-arrow-and-parquet) for details.

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -410,7 +410,7 @@ hyperfine --warmup 5 "ReadStat_App.exe -f crates\readstat-tests\tests\data\cars.
 
 ```sh
 # Linux and macOS
-hyperfine --prepare "sync; echo 3 | sudo tee /proc/sys/vm/drop_caches" "readstat -f crates/readstat-tests/tests/data/cars.sas7bdat crates/readstat-tests/tests/data/cars_c.csv" "./target/release/readstat data tests/data/cars.sas7bdat --output crates/readstat-tests/tests/data/cars_rust.csv"
+hyperfine --prepare "sync; echo 3 | sudo tee /proc/sys/vm/drop_caches" "readstat -f crates/readstat-tests/tests/data/cars.sas7bdat crates/readstat-tests/tests/data/cars_c.csv" "./target/release/readstat convert crates/readstat-tests/tests/data/cars.sas7bdat --output crates/readstat-tests/tests/data/cars_rust.csv"
 ```
 
 Other, future, benchmarking may be performed now that [channels and threads](https://github.com/curtisalexander/readstat-rs/issues/28) have been developed.

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -83,7 +83,7 @@ READSTAT_REGEN_BINDINGS=1 cargo build -p readstat-sys --features buildtime_bindg
 
 This invokes [bindgen](https://rust-lang.github.io/rust-bindgen/), which requires [LLVM / `libclang`](https://rust-lang.github.io/rust-bindgen/requirements.html#clang) to be installed. On Windows specifically, you also need to set `LIBCLANG_PATH` (e.g. `C:\Program Files\LLVM\lib`). The build script always writes the regenerated file to `OUT_DIR` (for the current compile); setting `READSTAT_REGEN_BINDINGS=1` additionally refreshes the target's checked-in file under `src/bindings/` (`bindings_<os>_<arch>.rs`; the `x86_64-pc-windows-gnu` target uses `bindings_windows_gnu_x86_64.rs`), so the diff can be committed. Without the env var the feature never touches committed files — so a workspace-wide `--all-features` build can't silently dirty the bindings. Regeneration must be repeated on each supported target — the **readstat-sys cross-platform CI** workflow (`regen` jobs) can do this for you (`workflow_dispatch` → download artifacts → commit); see [CI-CD.md](CI-CD.md) for the full procedure.
 
-`wasm32-unknown-emscripten` builds require `--features buildtime_bindgen` because the emsdk sysroot can't be reproduced from a checked-in file.
+Direct `readstat-sys` builds for `wasm32-unknown-emscripten` require `--features buildtime_bindgen` because the emsdk sysroot can't be reproduced from a checked-in file. The high-level `readstat` crate enables that sys-crate feature automatically on Emscripten targets.
 
 ## Linking Summary
 

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -6,7 +6,7 @@ The CI/CD workflow can be triggered in multiple ways:
 
 ## 1. Tag Push (Release)
 
-Push a `v*` tag (e.g. `v0.25.1`) to trigger a full release build with GitHub
+Push a `v*` tag (e.g. `v0.26.0`) to trigger a full release build with GitHub
 Release artifacts. Only `v*` tags trigger releases, and only
 `readstat`/`readstat-cli` releases are tagged — sys-crate releases set
 `tag = false` in their `release.toml` and are crates.io-only events with no
@@ -24,7 +24,7 @@ git push
 git tag -a v0.1.0 -m "v0.1.0"
 
 # push local tag to remote
-git push origin --tags
+git push origin v0.1.0
 ```
 
 To delete and recreate tags:
@@ -95,6 +95,8 @@ Repository dispatch event types for API triggers:
 :memo: API triggers only build artifacts and do not create GitHub releases. To create a release, use a [tag push](#1-tag-push-release).
 
 ## MSRV Check (`msrv` job in `.github/workflows/main.yml`)
+
+The main verification job runs workspace all-feature clippy, checks, and tests (SQL is a default feature), Arrow lockstep, and the advertised Rust server and PyO3 extension. A separate required `wasm` job installs Emscripten and performs a release build for `wasm32-unknown-emscripten`; host formatting and clippy remain in the main verification job. Tag builds depend on both required jobs before creating release notes or binaries. Specialized cross-platform sys jobs remain separate.
 
 Non-tag pushes and PRs also run an `msrv` job that type-checks the workspace on
 the exact toolchain declared in `[workspace.package] rust-version` (currently

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -94,9 +94,23 @@ Repository dispatch event types for API triggers:
 
 :memo: API triggers only build artifacts and do not create GitHub releases. To create a release, use a [tag push](#1-tag-push-release).
 
-## MSRV Check (`msrv` job in `.github/workflows/main.yml`)
+## Required CI tiers (`.github/workflows/main.yml`)
 
-The main verification job runs workspace all-feature clippy, checks, and tests (SQL is a default feature), Arrow lockstep, and the advertised Rust server and PyO3 extension. A separate required `wasm` job installs Emscripten and performs a release build for `wasm32-unknown-emscripten`; host formatting and clippy remain in the main verification job. Tag builds depend on both required jobs before creating release notes or binaries. Specialized cross-platform sys jobs remain separate.
+Every PR runs three independent required gates in parallel:
+
+| Job | Responsibility |
+|-----|----------------|
+| `verify` | Fast feedback: formatting, non-SQL format clippy/check, minimal-feature build and tests, book, host WASM lint, and package contents. |
+| `sql` | The one authoritative all-feature clippy, workspace test, and rustdoc build, including default DataFusion SQL, followed by the advertised Rust server and PyO3 extension builds using a shared target directory. |
+| `wasm` | A real Emscripten release build for `wasm32-unknown-emscripten` plus a Node smoke test against a SAS fixture. |
+
+Rust and rustdoc warnings are denied throughout CI. Release-producing tag jobs
+depend on all three gates plus the blocking Miri and AddressSanitizer jobs
+before creating release notes or binaries. The specialized cross-platform sys
+workflow remains separate and deliberately does not rebuild DataFusion on each
+native target.
+
+## MSRV Check (`msrv` job in `.github/workflows/main.yml`)
 
 Non-tag pushes and PRs also run an `msrv` job that type-checks the workspace on
 the exact toolchain declared in `[workspace.package] rust-version` (currently
@@ -125,13 +139,13 @@ All builds (regardless of trigger method) upload artifacts that can be downloade
 
 ## readstat-sys Cross-Platform CI (`.github/workflows/readstat-sys-ci.yml`)
 
-A separate workflow guards the FFI bindings. The `readstat-sys` and `readstat-iconv-sys` crates ship **checked-in, per-target pre-generated bindings** so that downstream builds need no `libclang`. This workflow proves those files are correct and reproducible. It runs on PRs / pushes touching `crates/readstat-sys/**`, `crates/readstat-iconv-sys/**`, `Cargo.toml`, `Cargo.lock`, or the workflow file, and supports `workflow_dispatch`.
+A separate workflow guards the FFI bindings. The `readstat-sys` and `readstat-iconv-sys` crates ship **checked-in, per-target pre-generated bindings** so that downstream builds need no `libclang`. This workflow proves those files are correct and reproducible. It runs weekly, supports `workflow_dispatch`, and runs on PRs / pushes touching `crates/readstat-sys/**`, `crates/readstat-iconv-sys/**`, platform-sensitive integration tests, `Cargo.toml`, `Cargo.lock`, or the workflow file.
 
 Three jobs:
 
 | Job | Runs on | What it does |
 |-----|---------|--------------|
-| `consume` | linux x86_64/aarch64, macOS x86_64/aarch64, windows-msvc x86_64, windows-gnu x86_64 | Builds + tests the workspace using the **committed** `bindings_<os>_<arch>.rs` — the load-bearing check that each file matches that platform's real ABI. |
+| `consume` | linux x86_64/aarch64, macOS x86_64/aarch64, windows-msvc x86_64, windows-gnu x86_64 | Builds the workspace without default features and runs focused parser, encoding, and malformed-input tests using the **committed** bindings. SQL is tested once by the main `sql` job instead of compiling DataFusion six times. |
 | `regen` | same matrix | Regenerates each target's bindings with `--features buildtime_bindgen` + `READSTAT_REGEN_BINDINGS=1`, uploads the result as artifact `bindings-<target>`, and **fails on drift** if it differs from the committed file. |
 | `regen-iconv` | windows x86_64 | Same idea for `readstat-iconv-sys`; artifact `iconv-bindings-windows`. |
 

--- a/docs/MEMORY-SAFETY.md
+++ b/docs/MEMORY-SAFETY.md
@@ -6,7 +6,10 @@ This project contains unsafe Rust code (FFI callbacks, pointer casts, memory-map
 
 ## CI Jobs
 
-All five jobs run on every workflow dispatch and tag push, in parallel with the build jobs. Any memory error fails the job with a nonzero exit code — except the experimental `asan-windows-full` job, which is marked `continue-on-error` and does not block the workflow.
+All five jobs run nightly, on every workflow dispatch, and on every tag push,
+in parallel with the build jobs. Any memory error fails the job with a nonzero
+exit code — except the experimental `asan-windows-full` job, which is marked
+`continue-on-error` and does not block the workflow.
 
 ### Miri (Rust undefined behavior)
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -30,8 +30,8 @@ git push origin main vX.Y.Z
 .\scripts\vendor.ps1 prepare      # Windows
 
 #    Publish (in dependency order)
-cargo publish -p readstat-iconv-sys
-cargo publish -p readstat-sys
+cargo publish -p readstat-iconv-sys --allow-dirty
+cargo publish -p readstat-sys --allow-dirty
 cargo publish -p readstat
 cargo publish -p readstat-cli
 
@@ -117,10 +117,12 @@ Add an entry for the new version:
 
 This runs:
 - `cargo fmt --all -- --check` — formatting
-- `cargo clippy --workspace` — linting
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — linting
 - `readstat-wasm` fmt and clippy (excluded from workspace, checked separately)
-- `cargo test --workspace` — all tests
-- `cargo doc --workspace --no-deps` — documentation build
+- all-feature/all-target workspace checks and tests (including default SQL)
+- Arrow/DataFusion lockstep, all-feature rustdocs, and mdBook
+- advertised Rust API-server and PyO3 checks
+- WASM host fmt/clippy and an Emscripten release build when that toolchain is available (otherwise a prominent warning)
 - `cargo deny check` — license and security audit (if installed)
 - Version consistency checks
 - CHANGELOG entry check
@@ -133,7 +135,7 @@ Fix any failures before proceeding.
 - [ ] README.md is up to date
 - [ ] Documentation reflects any API changes
 - [ ] Architecture docs (`docs/ARCHITECTURE.md`) are current
-- [ ] mdbook builds cleanly: `./scripts/build-book.sh`
+- [ ] mdbook builds cleanly: `bash scripts/build-book.sh`
 - [ ] `readstat-wasm` builds and exports are up to date (excluded from workspace; not published to crates.io)
 
 ---

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -5,7 +5,7 @@
 To perform unit / integration tests, run the following.
 
 ```
-cargo test --workspace
+cargo test --workspace --all-features
 ```
 
 To run only integration tests:
@@ -13,6 +13,8 @@ To run only integration tests:
 ```
 cargo test -p readstat-tests
 ```
+
+SQL is a default feature, so the workspace command includes SQL tests without extra flags. Before release, use `scripts/release-check.sh` (or `.ps1`) for all-target clippy/checks, docs, book, examples, dependency, packaging, and WASM gates.
 
 ## Datasets
 Formally tested (via integration tests) against the following datasets.  See the [README.md](../crates/readstat-tests/tests/data/README.md) for data sources.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -25,7 +25,7 @@ After either [building](BUILDING.md) or [installing](../README.md#package-cli-in
     - variable formats
     - arrow data types
 - `preview` &rarr; writes the first 10 rows (or optionally the number of rows provided by the user) of parsed data in `csv` format to standard out
-- `data` &rarr; writes parsed data in `csv`, `feather`, `ndjson`, or `parquet` format to a file
+- `convert` &rarr; converts to `csv`, `feather`, `ndjson`, or `parquet`
 
 ## Metadata
 To write metadata to standard out, invoke the following.
@@ -54,7 +54,7 @@ In that mode the reported row count is `0` and parsing returns as soon as the he
 
 ### Suppressing the progress bar
 
-By default `metadata`, `preview`, and `data` render a progress bar while the file is being parsed.  Pass `--no-progress` (available on all three subcommands) to suppress it &mdash; useful in CI logs, when piping output, or when launching `readstat` from another process.
+By default `metadata`, `preview`, and `convert` render a progress bar while the file is being parsed. Pass `--no-progress` to suppress it.
 
 ### Search for a column with `jq`
 
@@ -91,77 +91,81 @@ To write the first 100 rows of parsed data (as a `csv`) to standard out, invoke 
 readstat preview /some/dir/to/example.sas7bdat --rows 100
 ```
 
-## Data
-:memo: The `data` subcommand includes a parameter for `--format`, which is the file format that is to be written.  Currently, the following formats have been implemented:
+## Convert
+`convert` infers output from `.csv`, `.feather`, `.ndjson`, or `.parquet`. An explicit `--format` must match the extension; unknown extensions and mismatches are errors. With no `--output`, CSV is written to stdout. Diagnostics are written to stderr.
+
+The old `data` spelling remains a compatibility alias; new usage should use `convert`.
+
+Supported formats:
 - `csv`
 - `feather`
 - `ndjson`
 - `parquet`
 
-By default `data` refuses to overwrite an existing output file.  Pass `--overwrite` to replace it:
+By default `convert` refuses to overwrite an existing output file. Pass `--overwrite` to replace it:
 
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --format parquet --overwrite
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --overwrite
 ```
 
 ### `csv`
 To write parsed data (as `csv`) to a file, invoke the following (default is to write all parsed data to the specified file).
 
-The default `--format` is `csv`.  Thus, the parameter is elided from the below examples.
+Omit `--output` to stream CSV to stdout (for example, `readstat convert example.sas7bdat | head`). With a `.csv` output path, the format is inferred:
 
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.csv
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.csv
 ```
 
 To write the first 100 rows of parsed data (as `csv`) to a file, invoke the following.
 
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.csv --rows 100
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.csv --rows 100
 ```
 
 ### `feather`
 To write parsed data (as `feather`) to a file, invoke the following (default is to write all parsed data to the specified file).
 
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.feather --format feather
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.feather
 ```
 
 To write the first 100 rows of parsed data (as `feather`) to a file, invoke the following.
 
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.feather --format feather --rows 100
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.feather --rows 100
 ```
 
 ### `ndjson`
 To write parsed data (as `ndjson`) to a file, invoke the following (default is to write all parsed data to the specified file).
 
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.ndjson --format ndjson
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.ndjson
 ```
 
 To write the first 100 rows of parsed data (as `ndjson`) to a file, invoke the following.
 
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.ndjson --format ndjson --rows 100
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.ndjson --rows 100
 ```
 
 ### `parquet`
 To write parsed data (as `parquet`) to a file, invoke the following (default is to write all parsed data to the specified file).
 
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --format parquet
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet
 ```
 
 To write the first 100 rows of parsed data (as `parquet`) to a file, invoke the following.
 
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --format parquet --rows 100
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --rows 100
 ```
 
 To write parsed data (as `parquet`) to a file with specific compression settings, invoke the following:
 
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --format parquet --compression zstd --compression-level 3
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --compression zstd --compression-level 3
 ```
 
 ## Column Selection
@@ -196,7 +200,7 @@ for v in md['vars'].values():
 ### Step 2: Select columns on the command line
 
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output out.parquet --format parquet --columns Brand,Model,EngineSize
+readstat convert /some/dir/to/example.sas7bdat --output out.parquet --columns Brand,Model,EngineSize
 ```
 
 ### Step 2 (alt): Select columns from a file
@@ -211,7 +215,7 @@ EngineSize
 
 Then pass it to the CLI:
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output out.parquet --format parquet --columns-file columns.txt
+readstat convert /some/dir/to/example.sas7bdat --output out.parquet --columns-file columns.txt
 ```
 
 ### Preview with column selection
@@ -221,7 +225,7 @@ readstat preview /some/dir/to/example.sas7bdat --columns Brand,Model,EngineSize
 ```
 
 ## Parallelism
-The `data` subcommand includes parameters for both _**parallel reading**_ and _**parallel writing**_:
+The `convert` subcommand includes parameters for both _**parallel reading**_ and _**parallel writing**_:
 
 ### Parallel Reading (`--parallel`)
 If invoked, the _**reading**_ of a `sas7bdat` will occur in parallel.  If the total rows to process is greater than `stream-rows` (if unset, the default rows to stream is 10,000), then each chunk of rows is read in parallel.  Note that all processors on the user's machine are used with the `--parallel` option.  In the future, may consider allowing the user to throttle this number.
@@ -238,7 +242,7 @@ When combined with `--parallel`, the `--parallel-write` flag enables _**parallel
 
 Example usage:
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --format parquet --parallel --parallel-write
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --parallel --parallel-write
 ```
 
 ### Memory Buffer Size (`--parallel-write-buffer-mb`)
@@ -251,7 +255,7 @@ Smaller buffers will cause data to spill to disk sooner, while larger buffers ke
 
 Example with custom buffer size:
 ```sh
-readstat data /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --format parquet --parallel --parallel-write --parallel-write-buffer-mb 200
+readstat convert /some/dir/to/example.sas7bdat --output /some/dir/to/example.parquet --parallel --parallel-write --parallel-write-buffer-mb 200
 ```
 
 :heavy_exclamation_mark: Parallel writing may write batches out of order. This is acceptable for Parquet files as the row order is preserved when merged.
@@ -337,20 +341,16 @@ Parallel Write (--parallel --parallel-write)
 
 ### SQL Queries (`--sql` / `--sql-file`)
 
-:warning: **`--sql` is feature-gated.** SQL support is **not** enabled by default. The binary published via `cargo install readstat-cli` does **not** include it; to get `--sql`/`--sql-file`, install with the feature explicitly:
-
-```sh
-cargo install readstat-cli --features sql
-```
+SQL is enabled by default. Library users have synchronous and asynchronous buffered and streaming APIs. Buffered batches support repeated scans; only channel-backed streaming input is single-execution because execution consumes its receiver.
 
 Provide the query inline with `--sql "SELECT ..."`, or point at a file containing the query with `--sql-file path/to/query.sql`. The table name is the input file stem (e.g. `cars` for `cars.sas7bdat`). `--sql` and `--sql-file` are mutually exclusive with each other and with `--columns`/`--columns-file`.
 
 ```sh
 # inline query
-readstat data cars.sas7bdat --output out.parquet --sql "SELECT make, mpg FROM cars WHERE mpg > 30"
+readstat convert cars.sas7bdat --output out.parquet --sql "SELECT make, mpg FROM cars WHERE mpg > 30"
 
 # query from a file
-readstat data cars.sas7bdat --output out.parquet --sql-file query.sql
+readstat convert cars.sas7bdat --output out.parquet --sql-file query.sql
 ```
 
 SQL queries require the full dataset to be materialized in memory via DataFusion's `MemTable` before query execution.  For large files this may result in significant memory usage.  Queries that filter rows (e.g. `SELECT ... WHERE ...`) will reduce the _output_ size but the _input_ must still be fully loaded.
@@ -442,7 +442,7 @@ for (field in schema) {
 ```
 
 ## Reader
-The `preview` and `data` subcommands include a parameter for `--reader`.  The possible values for `--reader` include the following.
+The `preview` and `convert` subcommands include a parameter for `--reader`.  The possible values for `--reader` include the following.
 - `mem` &rarr; Parse and read the entire `sas7bdat` into memory before writing to either standard out or a file
 - `stream` (default) &rarr; Parse and read at most `stream-rows` into memory before writing to disk
     - `stream-rows` may be set via the command line parameter `--stream-rows` or if elided will default to 10,000 rows
@@ -454,7 +454,7 @@ The `preview` and `data` subcommands include a parameter for `--reader`.  The po
 - In addition, by enabling these options as command line parameters [hyperfine](BENCHMARKING.md#benchmarking-with-hyperfine) may be used to benchmark across an assortment of file sizes
 
 ## Debug
-Debug information is printed to standard out by setting the environment variable `RUST_LOG=debug` before the call to `readstat`.
+Debug information is printed to standard error by setting the environment variable `RUST_LOG=debug` before the call to `readstat`.
 
 :warning: This is quite verbose!  If using the [preview](#preview-data) or [data](#data) subcommand, will write debug information for _every single value_!
 
@@ -475,5 +475,5 @@ For full details run with `--help`.
 readstat --help
 readstat metadata --help
 readstat preview --help
-readstat data --help
+readstat convert --help
 ```

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -6,7 +6,7 @@
 #
 # Prerequisites (one-time, local):
 #   brew install vhs          # pulls in ffmpeg + ttyd
-#   cargo build --release -p readstat-cli --features sql
+#   cargo build --release -p readstat-cli
 #
 # Regenerate the GIF:
 #   vhs docs/demo.tape        # run from the repo root
@@ -14,7 +14,7 @@
 # Notes:
 #   * demo.sh handles its own typewriter pacing via DEMO_SPEED, so we let it
 #     drive the timing and just record the result here.
-#   * DEMO_SQL=1 includes the SQL beat (needs the --features sql build above).
+#   * DEMO_SQL=1 includes the SQL beat (enabled by default).
 
 Output docs/demo.gif
 

--- a/docs/plan-numeric-type-narrowing.md
+++ b/docs/plan-numeric-type-narrowing.md
@@ -187,7 +187,7 @@ lock the schema and stream normally.
 Let the user specify desired types per column via CLI flags or a schema file:
 
 ```bash
-readstat data input.sas7bdat --output out.parquet \
+readstat convert input.sas7bdat --output out.parquet \
     --type-override "flag_col=bool,count_col=int32"
 ```
 

--- a/docs/readstat-cheatsheet.html
+++ b/docs/readstat-cheatsheet.html
@@ -281,7 +281,7 @@
         <div class="step">
           <div class="step-num">4</div>
           <h3>Convert</h3>
-          <p><span class="cmd">readstat data file.sas7bdat -o out.parquet -f parquet</span></p>
+          <p><span class="cmd">readstat convert file.sas7bdat -o out.parquet</span></p>
         </div>
       </div>
     </section>
@@ -310,11 +310,12 @@
     <!-- ── Data Conversion ── -->
     <section class="section theme-amber">
       <h2>Data Conversion</h2>
-      <div class="row"><span class="k">readstat data FILE -o OUT</span><span class="d">Convert (default: CSV)</span></div>
+      <div class="row"><span class="k">readstat convert FILE [-o OUT]</span><span class="d">Extension selects format; no output = CSV stdout</span></div>
       <div class="row"><span class="k">-f csv</span><span class="d">CSV (default)</span></div>
       <div class="row"><span class="k">-f feather</span><span class="d">Feather / Arrow IPC</span></div>
       <div class="row"><span class="k">-f ndjson</span><span class="d">Newline-delimited JSON</span></div>
       <div class="row"><span class="k">-f parquet</span><span class="d">Apache Parquet</span></div>
+      <div class="tip">An explicit <span class="cmd">--format</span> must match the output extension. Unknown extensions and mismatches are errors; diagnostics always use stderr.</div>
       <div class="row"><span class="k">--rows 1000</span><span class="d">Limit rows</span></div>
       <div class="row"><span class="k">--overwrite</span><span class="d">Overwrite existing output</span></div>
       <div class="row"><span class="k">--columns A,B,C</span><span class="d">Select columns</span></div>
@@ -331,7 +332,7 @@
       <div class="row"><span class="k">--compression lz4-raw</span><span class="d">Fastest decompression</span></div>
       <div class="row"><span class="k">--compression uncompressed</span><span class="d">No compression</span></div>
       <div class="row"><span class="k">--compression-level N</span><span class="d">Level (codec-specific)</span></div>
-      <div class="tip"><strong>Example:</strong> <span class="cmd">readstat data f.sas7bdat -o f.parquet -f parquet --compression zstd --compression-level 3</span></div>
+      <div class="tip"><strong>Example:</strong> <span class="cmd">readstat convert f.sas7bdat -o f.parquet --compression zstd --compression-level 3</span></div>
     </section>
 
     <!-- ── Parallelism ── -->
@@ -366,10 +367,10 @@
 
     <!-- ── SQL Queries ── -->
     <section class="section theme-sky">
-      <h2>SQL Queries <span style="font-size:0.62rem; font-weight:600; color:#0369a1; background:#f0f9ff; border:1px solid #bae6fd; padding:1px 5px; border-radius:3px; margin-left:4px; letter-spacing:0.02em;">feature: sql</span></h2>
+      <h2>SQL Queries <span style="font-size:0.62rem; font-weight:600; color:#0369a1; background:#f0f9ff; border:1px solid #bae6fd; padding:1px 5px; border-radius:3px; margin-left:4px; letter-spacing:0.02em;">default</span></h2>
       <div class="row"><span class="k">--sql "SELECT ..."</span><span class="d">Inline query</span></div>
       <div class="row"><span class="k">--sql-file query.sql</span><span class="d">Query from file</span></div>
-      <div class="tip"><strong>Install:</strong> <span class="cmd">cargo install readstat-cli --features sql</span>. Table name = input file stem (e.g. <span class="cmd">cars</span> for <span class="cmd">cars.sas7bdat</span>). Mutually exclusive with <span class="cmd">--columns</span>/<span class="cmd">--columns-file</span>. Full dataset is materialised in memory via DataFusion.</div>
+      <div class="tip">SQL is included by default. Table name = input file stem (e.g. <span class="cmd">cars</span>). Mutually exclusive with <span class="cmd">--columns</span>/<span class="cmd">--columns-file</span>.</div>
     </section>
 
     <!-- ── Metadata in Output Files ── -->
@@ -396,7 +397,7 @@
         </div>
         <div class="scenario">
           <div class="scenario-title">Production conversion</div>
-          <div class="row"><span class="k">readstat data big.sas7bdat -o big.parquet -f parquet --compression zstd</span></div>
+          <div class="row"><span class="k">readstat convert big.sas7bdat -o big.parquet --compression zstd</span></div>
           <div class="row"><span class="k">... --parallel --parallel-write</span><span class="d">Max throughput</span></div>
           <div class="row"><span class="k">... --columns-file keep.txt</span><span class="d">Only needed columns</span></div>
           <div class="row"><span class="k">... --rows 100000</span><span class="d">Partial extract</span></div>

--- a/examples/api-demo/README.md
+++ b/examples/api-demo/README.md
@@ -282,7 +282,7 @@ The multipart field name must be `file`. Binary formats include a `Content-Dispo
 HTTP upload → Axum multipart extraction → Vec<u8>
   → spawn_blocking {
       ReadStatMetadata::read_metadata_from_bytes()
-      ReadStatData::read_data_from_bytes() → Arrow RecordBatch
+      ReadStatReader::from_bytes(...).read() → Arrow RecordBatch
       write_batch_to_{csv,ndjson,parquet,feather}_bytes()
     }
   → HTTP response
@@ -297,7 +297,7 @@ HTTP upload → FastAPI UploadFile → bytes
   → readstat_py.read_to_{csv,ndjson,parquet,feather}(bytes)
     → [PyO3 boundary]
       → ReadStatMetadata::read_metadata_from_bytes()
-      → ReadStatData::read_data_from_bytes() → Arrow RecordBatch
+      → ReadStatReader::from_bytes(...).read() → Arrow RecordBatch
       → write_batch_to_*_bytes()
     → [back to Python]
   → HTTP response

--- a/examples/api-demo/python-server/readstat_py/Cargo.toml
+++ b/examples/api-demo/python-server/readstat_py/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 readstat = { path = "../../../../crates/readstat" }
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = { version = "0.27", features = ["extension-module"] }
 serde_json = "1"

--- a/examples/api-demo/python-server/readstat_py/src/lib.rs
+++ b/examples/api-demo/python-server/readstat_py/src/lib.rs
@@ -1,63 +1,54 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use readstat::{ReadStatData, ReadStatError, ReadStatMetadata};
+use readstat::{ReadStatError, ReadStatReader, arrow_array::RecordBatch};
 
 fn err_to_py(e: ReadStatError) -> PyErr {
     PyValueError::new_err(e.to_string())
 }
 
-fn read_batch(bytes: &[u8], row_limit: Option<u32>) -> Result<ReadStatData, ReadStatError> {
-    let mut md = ReadStatMetadata::new();
-    md.read_metadata_from_bytes(bytes, false)?;
-
-    let end = match row_limit {
-        Some(n) => n.min(md.row_count as u32),
-        None => md.row_count as u32,
-    };
-
-    let mut d = ReadStatData::new().set_no_progress(true).init(md, 0, end);
-    d.read_data_from_bytes(bytes)?;
-    Ok(d)
+fn read_batch(bytes: &[u8], row_limit: Option<u32>) -> Result<RecordBatch, ReadStatError> {
+    let reader = ReadStatReader::from_bytes(bytes);
+    let row_count = u32::try_from(reader.metadata()?.row_count)?;
+    reader
+        .rows(0, row_limit.map(|limit| limit.min(row_count)))
+        .read()
 }
 
 #[pyfunction]
 #[pyo3(signature = (data,))]
 fn read_metadata(data: &[u8]) -> PyResult<String> {
-    let mut md = ReadStatMetadata::new();
-    md.read_metadata_from_bytes(data, false).map_err(err_to_py)?;
+    let md = ReadStatReader::from_bytes(data)
+        .metadata()
+        .map_err(err_to_py)?;
     serde_json::to_string(&md).map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 #[pyfunction]
 #[pyo3(signature = (data, row_limit=None))]
 fn read_to_csv(data: &[u8], row_limit: Option<u32>) -> PyResult<Vec<u8>> {
-    let d = read_batch(data, row_limit).map_err(err_to_py)?;
-    let batch = d.batch.as_ref().unwrap();
-    readstat::write_batch_to_csv_bytes(batch).map_err(err_to_py)
+    let batch = read_batch(data, row_limit).map_err(err_to_py)?;
+    readstat::write_batch_to_csv_bytes(&batch).map_err(err_to_py)
 }
 
 #[pyfunction]
 #[pyo3(signature = (data, row_limit=None))]
 fn read_to_ndjson(data: &[u8], row_limit: Option<u32>) -> PyResult<Vec<u8>> {
-    let d = read_batch(data, row_limit).map_err(err_to_py)?;
-    let batch = d.batch.as_ref().unwrap();
-    readstat::write_batch_to_ndjson_bytes(batch).map_err(err_to_py)
+    let batch = read_batch(data, row_limit).map_err(err_to_py)?;
+    readstat::write_batch_to_ndjson_bytes(&batch).map_err(err_to_py)
 }
 
 #[pyfunction]
 #[pyo3(signature = (data, row_limit=None))]
 fn read_to_parquet(data: &[u8], row_limit: Option<u32>) -> PyResult<Vec<u8>> {
-    let d = read_batch(data, row_limit).map_err(err_to_py)?;
-    let batch = d.batch.as_ref().unwrap();
-    readstat::write_batch_to_parquet_bytes(batch).map_err(err_to_py)
+    let batch = read_batch(data, row_limit).map_err(err_to_py)?;
+    readstat::write_batch_to_parquet_bytes(&batch).map_err(err_to_py)
 }
 
 #[pyfunction]
 #[pyo3(signature = (data, row_limit=None))]
 fn read_to_feather(data: &[u8], row_limit: Option<u32>) -> PyResult<Vec<u8>> {
-    let d = read_batch(data, row_limit).map_err(err_to_py)?;
-    let batch = d.batch.as_ref().unwrap();
-    readstat::write_batch_to_feather_bytes(batch).map_err(err_to_py)
+    let batch = read_batch(data, row_limit).map_err(err_to_py)?;
+    readstat::write_batch_to_feather_bytes(&batch).map_err(err_to_py)
 }
 
 #[pymodule]

--- a/examples/api-demo/rust-server/src/main.rs
+++ b/examples/api-demo/rust-server/src/main.rs
@@ -5,7 +5,7 @@ use axum::{
     response::{IntoResponse, Json, Response},
     routing::{get, post},
 };
-use readstat::OutFormat;
+use readstat::{OutFormat, ReadStatReader};
 use serde::Deserialize;
 use tower_http::cors::CorsLayer;
 
@@ -50,13 +50,9 @@ async fn health() -> Json<serde_json::Value> {
 async fn metadata(multipart: Multipart) -> Result<Json<serde_json::Value>, AppError> {
     let bytes = extract_file_bytes(multipart).await?;
 
-    let md = tokio::task::spawn_blocking(move || {
-        let mut md = readstat::ReadStatMetadata::new();
-        md.read_metadata_from_bytes(&bytes, false)?;
-        Ok::<_, readstat::ReadStatError>(md)
-    })
-    .await
-    .unwrap()?;
+    let md = tokio::task::spawn_blocking(move || ReadStatReader::from_bytes(bytes).metadata())
+        .await
+        .map_err(|e| AppError(readstat::ReadStatError::Other(e.to_string())))??;
 
     serde_json::to_value(&md)
         .map(Json)
@@ -76,22 +72,13 @@ async fn preview(
     let max_rows = params.rows.unwrap_or(10);
 
     let csv_bytes = tokio::task::spawn_blocking(move || {
-        let mut md = readstat::ReadStatMetadata::new();
-        md.read_metadata_from_bytes(&bytes, false)?;
-
-        let end = (max_rows).min(md.row_count as u32);
-        let mut d = readstat::ReadStatData::new()
-            .set_no_progress(true)
-            .init(md, 0, end);
-        d.read_data_from_bytes(&bytes)?;
-
-        let batch = d.batch.as_ref().ok_or_else(|| {
-            readstat::ReadStatError::Other("parsing produced no data".into())
-        })?;
-        readstat::write_batch_to_csv_bytes(batch)
+        let reader = ReadStatReader::from_bytes(bytes);
+        let row_count = u32::try_from(reader.metadata()?.row_count)?;
+        let batch = reader.rows(0, Some(max_rows.min(row_count))).read()?;
+        readstat::write_batch_to_csv_bytes(&batch)
     })
     .await
-    .unwrap()?;
+    .map_err(|e| AppError(readstat::ReadStatError::Other(e.to_string())))??;
 
     Ok(([(header::CONTENT_TYPE, "text/csv")], csv_bytes).into_response())
 }
@@ -115,46 +102,33 @@ async fn data(
     let bytes = extract_file_bytes(multipart).await?;
 
     let (output_bytes, content_type, filename) = tokio::task::spawn_blocking(move || {
-        let mut md = readstat::ReadStatMetadata::new();
-        md.read_metadata_from_bytes(&bytes, false)?;
-
-        let row_count = md.row_count as u32;
-        let mut d = readstat::ReadStatData::new()
-            .set_no_progress(true)
-            .init(md, 0, row_count);
-        d.read_data_from_bytes(&bytes)?;
-
-        let batch = d.batch.as_ref().ok_or_else(|| {
-            readstat::ReadStatError::Other("parsing produced no data".into())
-        })?;
+        let batch = ReadStatReader::from_bytes(bytes).read()?;
         match fmt {
             OutFormat::Csv => Ok((
-                readstat::write_batch_to_csv_bytes(batch)?,
+                readstat::write_batch_to_csv_bytes(&batch)?,
                 "text/csv",
                 "data.csv",
             )),
             OutFormat::Ndjson => Ok((
-                readstat::write_batch_to_ndjson_bytes(batch)?,
+                readstat::write_batch_to_ndjson_bytes(&batch)?,
                 "application/x-ndjson",
                 "data.ndjson",
             )),
             OutFormat::Parquet => Ok((
-                readstat::write_batch_to_parquet_bytes(batch)?,
+                readstat::write_batch_to_parquet_bytes(&batch)?,
                 "application/octet-stream",
                 "data.parquet",
             )),
             OutFormat::Feather => Ok((
-                readstat::write_batch_to_feather_bytes(batch)?,
+                readstat::write_batch_to_feather_bytes(&batch)?,
                 "application/octet-stream",
                 "data.feather",
             )),
-            _ => Err(readstat::ReadStatError::Other(
-                "unsupported format".into(),
-            )),
+            _ => Err(readstat::ReadStatError::Other("unsupported format".into())),
         }
     })
     .await
-    .unwrap()?;
+    .map_err(|e| AppError(readstat::ReadStatError::Other(e.to_string())))??;
 
     let disposition = format!("attachment; filename=\"{filename}\"");
     Ok((

--- a/release.toml
+++ b/release.toml
@@ -8,7 +8,10 @@
 #
 # Then review the bump commit and tag, then:
 #
-#   git push origin main --follow-tags
+#   git push origin main vX.Y.Z
+#
+# Push the intended tag explicitly; never use --follow-tags, which may push
+# unrelated reachable annotated tags.
 #
 # The sys crates version independently — bump only the one whose C bindings
 # or vendored library changed (readstat-sys's dependency requirement on

--- a/scripts/build-book.sh
+++ b/scripts/build-book.sh
@@ -9,8 +9,8 @@
 # them into the output so the book can link to them.
 #
 # Usage:
-#   ./scripts/build-book.sh           # build book only
-#   ./scripts/build-book.sh --docs    # build book + rustdocs
+#   bash scripts/build-book.sh           # build book only
+#   bash scripts/build-book.sh --docs    # build book + rustdocs
 
 set -euo pipefail
 

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -12,13 +12,13 @@
 # Usage:
 #   ./scripts/demo.sh              # paced for recording (typewriter pauses)
 #   DEMO_SPEED=0 ./scripts/demo.sh # no pauses — CI smoke test
-#   DEMO_SQL=1 ./scripts/demo.sh   # include the SQL beat (needs --features sql)
+#   DEMO_SQL=1 ./scripts/demo.sh   # include the default SQL beat
 #
 # Environment:
 #   DEMO_SPEED  Seconds to pause before/after each command (default 1).
 #               Set to 0 for an instant, non-interactive run.
 #   DEMO_SQL    If "1", include the SQL aggregation beat. Requires a binary
-#               built with `--features sql`.
+#               built with default features.
 #   READSTAT    Override the binary/command used (whitespace-separated, e.g.
 #               "cargo run -q -p readstat-cli --"). Default: release binary if
 #               present, else a cargo-run fallback.
@@ -92,24 +92,24 @@ prompt "readstat preview cars.sas7bdat --columns Brand,Model,EngineSize,Cylinder
 echo; pause
 
 banner "5. Convert to compressed Parquet"
-prompt "readstat data cars.sas7bdat -o cars.parquet -f parquet --compression zstd --overwrite"
-"${RS[@]}" data cars.sas7bdat -o cars.parquet -f parquet --compression zstd --overwrite
+prompt "readstat convert cars.sas7bdat -o cars.parquet --compression zstd --overwrite"
+"${RS[@]}" convert cars.sas7bdat -o cars.parquet --compression zstd --overwrite
 prompt "ls -lh cars.parquet"
 ls -lh cars.parquet
 echo; pause
 
 banner "6. Convert a few rows to NDJSON"
-prompt "readstat data cars.sas7bdat -o cars.ndjson -f ndjson --rows 3 --overwrite"
-"${RS[@]}" data cars.sas7bdat -o cars.ndjson -f ndjson --rows 3 --overwrite
+prompt "readstat convert cars.sas7bdat -o cars.ndjson --rows 3 --overwrite"
+"${RS[@]}" convert cars.sas7bdat -o cars.ndjson --rows 3 --overwrite
 prompt "cat cars.ndjson"
 cat cars.ndjson
 echo; pause
 
 if [ "$DEMO_SQL" = "1" ]; then
-    banner "7. Query with SQL (requires a --features sql build)"
+    banner "7. Query with SQL (enabled by default)"
     SQL='SELECT "Brand", ROUND(AVG("CityMPG"),1) AS avg_city_mpg FROM cars GROUP BY "Brand" ORDER BY avg_city_mpg DESC LIMIT 8'
-    prompt "readstat data cars.sas7bdat --sql '$SQL' -o top.csv --overwrite"
-    "${RS[@]}" data cars.sas7bdat --sql "$SQL" -o top.csv --overwrite
+    prompt "readstat convert cars.sas7bdat --sql '$SQL' -o top.csv --overwrite"
+    "${RS[@]}" convert cars.sas7bdat --sql "$SQL" -o top.csv --overwrite
     prompt "cat top.csv"
     cat top.csv
     echo; pause

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -11,7 +11,7 @@
 #
 # Prerequisites (one-time):
 #   brew install vhs gifsicle          # vhs pulls in ffmpeg + ttyd
-#   cargo build --release -p readstat-cli --features sql
+#   cargo build --release -p readstat-cli
 #
 # Usage:
 #   ./scripts/record-demo.sh           # → docs/demo.gif
@@ -32,7 +32,7 @@ done
 if [ ! -x "target/release/readstat" ]; then
     echo "note: target/release/readstat not found — the demo will fall back to" >&2
     echo "      'cargo run', which is slower and noisier on screen. Build first:" >&2
-    echo "      cargo build --release -p readstat-cli --features sql" >&2
+    echo "      cargo build --release -p readstat-cli" >&2
 fi
 
 RAW="$(mktemp -t readstat-demo-raw.XXXXXX).gif"

--- a/scripts/release-check.ps1
+++ b/scripts/release-check.ps1
@@ -43,7 +43,7 @@ if ($LASTEXITCODE -eq 0) {
 
 # 2. Clippy
 Write-Host "Checking clippy..."
-cargo clippy --workspace --all-targets -- -D warnings *>$null
+cargo clippy --workspace --all-targets --all-features -- -D warnings *>$null
 if ($LASTEXITCODE -eq 0) {
     Write-Pass "cargo clippy"
 } else {
@@ -61,11 +61,19 @@ if (Test-Path $WasmDir) {
     } else {
         Write-Fail "readstat-wasm fmt — run 'cargo fmt' in crates\readstat-wasm\"
     }
-    cargo clippy -- -D warnings *>$null
+    cargo clippy --all-targets -- -D warnings *>$null
     if ($LASTEXITCODE -eq 0) {
         Write-Pass "readstat-wasm clippy"
     } else {
         Write-Fail "readstat-wasm clippy — warnings or errors found"
+    }
+    $emcc = Get-Command emcc -ErrorAction SilentlyContinue
+    $targets = rustup target list --installed 2>$null
+    if ($emcc -and ($targets -contains "wasm32-unknown-emscripten")) {
+        cargo build --target wasm32-unknown-emscripten --release *>$null
+        if ($LASTEXITCODE -eq 0) { Write-Pass "readstat-wasm Emscripten build" } else { Write-Fail "readstat-wasm Emscripten build failed" }
+    } else {
+        Write-Warn "Emscripten/emcc or wasm32-unknown-emscripten unavailable — skipping actual WASM build"
     }
     Pop-Location
 } else {
@@ -91,7 +99,13 @@ if ($toolchains -match "^$Msrv") {
 
 # 3. Tests
 Write-Host "Running tests..."
-cargo test --workspace *>$null
+cargo check --workspace --all-targets --all-features *>$null
+if ($LASTEXITCODE -eq 0) { Write-Pass "workspace all-feature/all-target check" } else { Write-Fail "workspace all-feature/all-target check" }
+cargo check -p readstat --no-default-features *>$null
+$readstatMinimal = $LASTEXITCODE
+cargo check -p readstat-cli --no-default-features *>$null
+if (($readstatMinimal -eq 0) -and ($LASTEXITCODE -eq 0)) { Write-Pass "minimal feature builds" } else { Write-Fail "minimal feature builds" }
+cargo test --workspace --all-features *>$null
 if ($LASTEXITCODE -eq 0) {
     Write-Pass "cargo test"
 } else {
@@ -100,12 +114,29 @@ if ($LASTEXITCODE -eq 0) {
 
 # 4. Doc build
 Write-Host "Checking doc build..."
-cargo doc --workspace --no-deps *>$null
+$lockContent = Get-Content (Join-Path $RootDir "Cargo.lock") -Raw
+$lockstep = $true
+foreach ($crate in @("arrow", "parquet")) {
+    $majors = $lockContent -split '\[\[package\]\]' | Where-Object { $_ -match "(?m)^name = `"$crate`"$" } | ForEach-Object {
+        if ($_ -match '(?m)^version = "(\d+)\.') { $Matches[1] }
+    } | Sort-Object -Unique
+    if (@($majors).Count -gt 1) { $lockstep = $false }
+}
+if ($lockstep) { Write-Pass "Arrow/DataFusion lockstep" } else { Write-Fail "Arrow/DataFusion lockstep" }
+cargo doc --workspace --all-features --no-deps *>$null
 if ($LASTEXITCODE -eq 0) {
     Write-Pass "cargo doc"
 } else {
     Write-Fail "cargo doc — build failed"
 }
+& (Join-Path $ScriptDir "build-book.ps1") *>$null
+if ($LASTEXITCODE -eq 0) { Write-Pass "mdBook" } else { Write-Fail "mdBook build failed" }
+
+Write-Host "Checking advertised examples..."
+cargo check --manifest-path (Join-Path $RootDir "examples\api-demo\rust-server\Cargo.toml") *>$null
+if ($LASTEXITCODE -eq 0) { Write-Pass "Rust API server" } else { Write-Fail "Rust API server" }
+cargo check --manifest-path (Join-Path $RootDir "examples\api-demo\python-server\readstat_py\Cargo.toml") *>$null
+if ($LASTEXITCODE -eq 0) { Write-Pass "PyO3 extension" } else { Write-Fail "PyO3 extension" }
 
 # 5. cargo-deny (optional)
 Write-Host "Checking dependencies..."
@@ -170,6 +201,8 @@ if (Test-Path $changelogPath) {
 Write-Host "Checking package contents..."
 $publishableCrates = @("readstat-iconv-sys", "readstat-sys", "readstat", "readstat-cli")
 foreach ($crate in $publishableCrates) {
+    cargo package -p $crate --allow-dirty --list *>$null
+    if ($LASTEXITCODE -eq 0) { Write-Pass "cargo package -p $crate --list" } else { Write-Fail "cargo package -p $crate --list" }
     # Test the exit code, not a grepped string ("warning: aborting" is no
     # longer printed by modern cargo, so matching it fails open).
     #
@@ -177,7 +210,7 @@ foreach ($crate in $publishableCrates) {
     # dependency fails with "no matching package named `<dep>` found" because
     # the dependency isn't on crates.io yet. That's expected — downgrade it to
     # a warning. Real packaging errors still fail.
-    $pkgOutput = cargo package -p $crate --allow-dirty 2>&1
+    $pkgOutput = cargo package -p $crate --locked --allow-dirty 2>&1
     if ($LASTEXITCODE -eq 0) {
         Write-Pass "cargo package -p $crate"
     } elseif ($pkgOutput -match "no matching package named") {
@@ -191,13 +224,10 @@ foreach ($crate in $publishableCrates) {
 Write-Host "Checking vendor status..."
 $vendorScript = Join-Path $ScriptDir "vendor.ps1"
 if (Test-Path $vendorScript) {
-    try {
-        & $vendorScript status 2>$null
-    } catch {
-        Write-Warn "Could not determine vendor status"
-    }
+    & $vendorScript status *>$null
+    if ($LASTEXITCODE -eq 0) { Write-Pass "vendor status" } else { Write-Fail "vendor status could not be verified" }
 } else {
-    Write-Warn "vendor.ps1 not found — skipping"
+    Write-Fail "vendor.ps1 not found"
 }
 
 # Summary

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -48,7 +48,7 @@ fi
 
 # 2. Clippy
 echo "Checking clippy..."
-if cargo clippy --workspace --all-targets -- -D warnings &>/dev/null; then
+if cargo clippy --workspace --all-targets --all-features -- -D warnings &>/dev/null; then
     pass "cargo clippy"
 else
     fail "cargo clippy — warnings or errors found"
@@ -63,10 +63,19 @@ if [ -d "$WASM_DIR" ]; then
     else
         fail "readstat-wasm fmt — run 'cargo fmt' in crates/readstat-wasm/"
     fi
-    if (cd "$WASM_DIR" && cargo clippy -- -D warnings) &>/dev/null; then
+    if (cd "$WASM_DIR" && cargo clippy --all-targets -- -D warnings) &>/dev/null; then
         pass "readstat-wasm clippy"
     else
         fail "readstat-wasm clippy — warnings or errors found"
+    fi
+    if command -v emcc &>/dev/null && rustup target list --installed | grep -qx wasm32-unknown-emscripten; then
+        if (cd "$WASM_DIR" && cargo build --target wasm32-unknown-emscripten --release) &>/dev/null; then
+            pass "readstat-wasm Emscripten build"
+        else
+            fail "readstat-wasm Emscripten build failed"
+        fi
+    else
+        warn "Emscripten/emcc or wasm32-unknown-emscripten unavailable — skipping actual WASM build"
     fi
 else
     warn "readstat-wasm directory not found — skipping"
@@ -89,7 +98,18 @@ fi
 
 # 3. Tests
 echo "Running tests..."
-if cargo test --workspace &>/dev/null; then
+if cargo check --workspace --all-targets --all-features &>/dev/null; then
+    pass "cargo check --workspace --all-targets --all-features"
+else
+    fail "workspace all-feature/all-target check failed"
+fi
+if cargo check -p readstat --no-default-features &>/dev/null \
+    && cargo check -p readstat-cli --no-default-features &>/dev/null; then
+    pass "minimal feature builds"
+else
+    fail "minimal feature builds"
+fi
+if cargo test --workspace --all-features &>/dev/null; then
     pass "cargo test"
 else
     fail "cargo test — some tests failed"
@@ -97,11 +117,21 @@ fi
 
 # 4. Doc build
 echo "Checking doc build..."
-if cargo doc --workspace --no-deps &>/dev/null; then
+if "$SCRIPT_DIR/check-arrow-lockstep.sh" &>/dev/null; then
+    pass "Arrow/DataFusion lockstep"
+else
+    fail "Arrow/DataFusion lockstep"
+fi
+if cargo doc --workspace --all-features --no-deps &>/dev/null; then
     pass "cargo doc"
 else
     fail "cargo doc — build failed"
 fi
+if bash "$SCRIPT_DIR/build-book.sh" &>/dev/null; then pass "mdBook"; else fail "mdBook build failed"; fi
+
+echo "Checking advertised examples..."
+if cargo check --manifest-path "$ROOT_DIR/examples/api-demo/rust-server/Cargo.toml" &>/dev/null; then pass "Rust API server"; else fail "Rust API server"; fi
+if cargo check --manifest-path "$ROOT_DIR/examples/api-demo/python-server/readstat_py/Cargo.toml" &>/dev/null; then pass "PyO3 extension"; else fail "PyO3 extension"; fi
 
 # 5. cargo-deny (optional)
 echo "Checking dependencies..."
@@ -163,6 +193,11 @@ fi
 echo "Checking package contents..."
 PUBLISHABLE_CRATES=("readstat-iconv-sys" "readstat-sys" "readstat" "readstat-cli")
 for crate in "${PUBLISHABLE_CRATES[@]}"; do
+    if cargo package -p "$crate" --allow-dirty --list &>/dev/null; then
+        pass "cargo package -p $crate --list"
+    else
+        fail "cargo package -p $crate --list"
+    fi
     # Test the exit code directly. Grepping stdout/stderr for a fixed string
     # (e.g. "warning: aborting") fails open — modern cargo doesn't print it, and
     # a pipe would mask cargo's exit status anyway. `cargo package` exits
@@ -173,7 +208,7 @@ for crate in "${PUBLISHABLE_CRATES[@]}"; do
     # the dependency isn't on crates.io yet. That's expected — downgrade it to
     # a warning so the first-publish run isn't littered with false failures.
     # Real packaging errors still fail.
-    if pkg_output=$(cargo package -p "$crate" --allow-dirty 2>&1); then
+    if pkg_output=$(cargo package -p "$crate" --locked --allow-dirty 2>&1); then
         pass "cargo package -p $crate"
     elif grep -q "no matching package named" <<<"$pkg_output"; then
         warn "cargo package -p $crate — path dependency not on crates.io yet (expected before first publish)"
@@ -184,7 +219,7 @@ done
 
 # 9. Vendor status
 echo "Checking vendor status..."
-"$SCRIPT_DIR/vendor.sh" status 2>/dev/null || warn "Could not determine vendor status"
+if "$SCRIPT_DIR/vendor.sh" status &>/dev/null; then pass "vendor status"; else fail "vendor status could not be verified"; fi
 
 # Summary
 echo ""


### PR DESCRIPTION
## Summary

- redesign the public reader/writer APIs around Arrow batches and clear lifecycle boundaries
- harden SQL streaming, atomic output publication, overwrite behavior, and CLI validation
- make `convert` canonical while retaining `data` as an alias and preserving clean stdout pipelines
- reorganize CLI ownership, update examples/docs, and expand release checks
- bump `readstat` and `readstat-cli` to 0.26.0
- add a required Emscripten build for the standalone WASM crate
- resolve current RustSec findings in `crossbeam-epoch` and `memmap2`

## Compatibility

This intentionally changes the unpublished pre-1.0 library API. The existing CLI compatibility alias remains available.

## Validation

- `./scripts/release-check.sh`: 24 passed
- workspace all-feature tests, clippy, docs, book, examples, package contents, and cargo-deny pass locally
- actual Emscripten linking is delegated to the new required CI job because the local Emscripten toolchain is unavailable
